### PR TITLE
docs: update publish-plugin command to use CI versioning

### DIFF
--- a/.claude/commands/publish-plugin.md
+++ b/.claude/commands/publish-plugin.md
@@ -2,78 +2,86 @@
 
 Publish a new version of the Quest Voiceover plugin to the RuneLite Plugin Hub.
 
-**Input:** $ARGUMENTS (optional: version number override, e.g., "1.2.0")
+**Input:** $ARGUMENTS (optional: additional context or instructions)
 
 ## Prerequisites
 
 - The plugin-hub fork must be cloned at `../plugin-hub`
 - GitHub CLI (`gh`) must be authenticated
 - All plugin changes must be committed and pushed to main
+- Version bump should already be done by CI (release-please)
 
 ## Important Rules
 
 - **NEVER use AI attestation** - no "Generated with Claude Code" footers or Co-Authored-By lines in any commits or PRs
+- **NEVER bump the version manually** - CI (release-please) handles versioning automatically
+- **Always pull main before starting** - ensure you have the latest version bump from CI
 
 ## Instructions
 
-1. **Get the currently published commit:**
+1. **Pull latest from main:**
+   - Run `git pull origin main` to get the latest changes (including CI version bumps)
+
+2. **Get current version:**
+   - Read the version from `build.gradle` (line with `version = 'X.X.X'`)
+
+3. **Get the currently published commit:**
    - Fetch `https://raw.githubusercontent.com/runelite/plugin-hub/master/plugins/quest-voiceover`
    - Extract the `commit=` value
 
-2. **Determine the new version:**
-   - If version provided in arguments, use that
-   - Otherwise, analyze commits between published commit and HEAD:
-     - Get current version from `build.gradle`
-     - If any commit starts with `feat:` or adds new functionality → bump minor version
-     - If any commit starts with `fix:` or `chore:` or `docs:` → bump patch version
-     - If any commit contains `BREAKING` or starts with `feat!:` → bump major version
-
-3. **Update version in build.gradle:**
-   - Find the line `version = 'X.X.X'`
-   - Update it to the new version number
-
-4. **Commit and push the version bump:**
-   - Stage build.gradle
-   - Commit with message: `chore: bump version to {version}`
-   - Push to origin main
-
-5. **Get the new commit hash:**
+4. **Get the HEAD commit hash:**
    - Run `git rev-parse HEAD` to get the full 40-character hash
 
-6. **Sync plugin-hub fork with upstream:**
+5. **Check for existing GitHub release:**
+   - Run `gh release view v{version}` to check if release exists
+   - If no release exists, warn the user that CI may not have completed yet
+
+6. **Check for existing plugin-hub PR:**
+   - Run `gh pr list --head update-quest-voiceover --repo runelite/plugin-hub --json number,url`
+   - Note whether a PR already exists
+
+7. **Sync plugin-hub fork with upstream:**
    - Navigate to `../plugin-hub`
    - Add upstream remote if not exists: `git remote add upstream https://github.com/runelite/plugin-hub.git`
    - Fetch upstream: `git fetch upstream`
    - Checkout master: `git checkout master`
    - Reset to upstream: `git reset --hard upstream/master`
 
-7. **Update the plugin file:**
+8. **Update the plugin file:**
    - Edit `plugins/quest-voiceover`
    - Update the `commit=` line with the new commit hash
 
-8. **Create branch and commit:**
-   - Create branch: `git checkout -b update-quest-voiceover`
+9. **Create branch and commit:**
+   - Create branch: `git checkout -B update-quest-voiceover`
    - Stage the plugin file
    - Commit with message: `quest-voiceover {version}`
 
-9. **Push and create PR:**
-   - Push branch: `git push -u origin update-quest-voiceover --force`
-   - Create PR to upstream with:
-     - Title: `Update quest-voiceover plugin to v{version}`
-     - Body: Use template below
+10. **Push branch:**
+    - Push branch: `git push -u origin update-quest-voiceover --force`
 
-10. **PR body template:**
+11. **Create or update PR:**
+    - If PR already exists: Update title and body using `gh api repos/runelite/plugin-hub/pulls/{pr_number} -X PATCH`
+    - If no PR exists: Create PR using `gh pr create`
+    - Title: `quest-voiceover {version}`
+    - Body: Use template below
+
+12. **PR body template:**
 ```
 Update quest-voiceover plugin to version {version}.
 
-Changes:
-- [List relevant changes from git log between published commit and new commit]
+**Release:** https://github.com/KevinEdry/runelite-quest-voiceover/releases/tag/v{version}
+
+### Features
+- [List feat: commits between published commit and HEAD]
+
+### Bug Fixes
+- [List fix: commits between published commit and HEAD]
 ```
 
-11. **Output the PR URL** when complete
+13. **Output the PR URL** when complete
 
 ## Additional Notes
 
-- If a PR already exists for the branch, the force-push will update it automatically
 - The plugin-hub fork should be at `../plugin-hub` relative to this repo
-- After creating the PR, return to the original repo directory
+- After creating/updating the PR, return to the original repo directory
+- If the GitHub release doesn't exist yet, wait for CI to complete before running this command


### PR DESCRIPTION
## Summary
- Remove manual version bumping - let CI (release-please) handle it
- Always pull main first to get latest version from CI
- Check for existing plugin-hub PR and update it instead of creating new
- Add GitHub release link to PR body template