### PR TITLE
docs: add GitHub issue templates for quest requests and bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: OSRS Wiki Quest Transcripts
+    url: https://oldschool.runescape.wiki/w/Category:Quest_transcript
+    about: Find quest transcripts for your request on the OSRS Wiki

--- a/.github/ISSUE_TEMPLATE/issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yml
@@ -1,0 +1,87 @@
+name: Issue Report
+description: Report an issue with a quest or specific dialog
+title: "[Issue] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to report issues with voiced quests or specific dialog lines.
+
+  - type: input
+    id: quest-name
+    attributes:
+      label: Quest Name
+      description: Which quest does this issue occur in?
+      placeholder: "e.g., X Marks the Spot"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What kind of issue are you experiencing?
+      options:
+        - Wrong voice line plays
+        - Voice line missing
+        - Audio doesn't play
+        - Audio quality issue
+        - Pronunciation error
+        - Dialog mismatch
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: character-name
+    attributes:
+      label: Character Name
+      description: Which character is affected? (if applicable)
+      placeholder: "e.g., Veos"
+    validations:
+      required: false
+
+  - type: textarea
+    id: dialog-text
+    attributes:
+      label: Dialog Text
+      description: The exact or approximate dialog text where the issue occurs
+      placeholder: "Paste the dialog text here..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the issue in detail
+      placeholder: "When I talk to Veos during step 3, the wrong voice line plays..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Start quest X
+        2. Talk to character Y
+        3. Select dialog option Z
+    validations:
+      required: false
+
+  - type: textarea
+    id: runelite-logs
+    attributes:
+      label: RuneLite Logs
+      description: |
+        Paste relevant logs from RuneLite. You can find logs at:
+        - Windows: `%USERPROFILE%\.runelite\logs\`
+        - macOS: `~/.runelite/logs/`
+        - Linux: `~/.runelite/logs/`
+      placeholder: "Paste relevant log entries here..."
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/quest-request.yml
+++ b/.github/ISSUE_TEMPLATE/quest-request.yml
@@ -1,0 +1,37 @@
+name: Quest Request
+description: Request a quest to be added with voice acting
+title: "[Quest Request] "
+labels: ["quest-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for requesting a quest! Please provide the quest transcript link from the OSRS Wiki.
+
+        You can find quest transcripts at: https://oldschool.runescape.wiki/w/Category:Quest_transcript
+
+  - type: input
+    id: quest-name
+    attributes:
+      label: Quest Name
+      description: The exact name of the quest as it appears in-game
+      placeholder: "e.g., Cook's Assistant"
+    validations:
+      required: true
+
+  - type: input
+    id: transcript-link
+    attributes:
+      label: Quest Transcript Link
+      description: Link to the OSRS Wiki quest transcript page
+      placeholder: "https://oldschool.runescape.wiki/w/Transcript:Cook%27s_Assistant"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other information that might be helpful (voice suggestions, priority, etc.)
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add issue template form for requesting new quests to be voiced (requires OSRS Wiki transcript link)
- Add issue template form for reporting bugs with quests or dialog (includes RuneLite logs field)
- Add config with link to OSRS Wiki quest transcripts

## Test plan
- [ ] Verify templates appear when creating a new issue on GitHub
- [ ] Test that form validation works (required fields)