### PR TITLE
feat: add Ko-fi donation button and update changelog message

### DIFF
--- a/src/main/java/com/quest/voiceover/QuestVoiceoverPanel.java
+++ b/src/main/java/com/quest/voiceover/QuestVoiceoverPanel.java
@@ -2,6 +2,7 @@ package com.quest.voiceover;
 
 import com.quest.voiceover.modules.database.DatabaseManager;
 import com.quest.voiceover.modules.database.DatabaseVersionManager;
+import com.quest.voiceover.utility.PluginVersionUtility;
 import net.runelite.api.Quest;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
@@ -12,10 +13,9 @@ import net.runelite.client.util.LinkBrowser;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Path2D;
 import java.awt.image.BufferedImage;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 import java.util.Set;
 
 public class QuestVoiceoverPanel extends PluginPanel
@@ -24,27 +24,29 @@ public class QuestVoiceoverPanel extends PluginPanel
     private static final String REQUEST_QUEST_URL = "https://github.com/KevinEdry/runelite-quest-voiceover/issues/new?template=quest-request.yml";
     private static final String REPORT_ISSUE_URL = "https://github.com/KevinEdry/runelite-quest-voiceover/issues/new?template=issue-report.yml";
     private static final String DISCORD_URL = "https://discord.com/invite/tkr6tEbXJr";
+    private static final String KOFI_URL = "https://ko-fi.com/kedry";
+
+    private static final int ICON_SIZE = 24;
+    private static final Color KOFI_RED = new Color(0xFF, 0x5E, 0x5B);
+
+    private static final double HEART_LOBE_RADIUS = ICON_SIZE * 0.20;
+    private static final double HEART_LOBE_CENTER_Y = ICON_SIZE * 0.34;
+    private static final double HEART_LEFT_LOBE_CENTER_X = ICON_SIZE * 0.32;
+    private static final double HEART_RIGHT_LOBE_CENTER_X = ICON_SIZE * 0.68;
+    private static final double HEART_BODY_TOP_LEFT_X = ICON_SIZE * 0.13;
+    private static final double HEART_BODY_TOP_RIGHT_X = ICON_SIZE * 0.87;
+    private static final double HEART_BODY_TOP_Y = ICON_SIZE * 0.40;
+    private static final double HEART_BODY_TIP_X = ICON_SIZE * 0.50;
+    private static final double HEART_BODY_TIP_Y = ICON_SIZE * 0.84;
 
     private static final ImageIcon ARROW_RIGHT_ICON;
     private static final ImageIcon GITHUB_ICON;
     private static final ImageIcon DISCORD_ICON;
+    private static final ImageIcon DONATION_ICON;
 
     static
     {
-        String version = "Unknown";
-        try (InputStream input = QuestVoiceoverPanel.class.getResourceAsStream("version.properties"))
-        {
-            if (input != null)
-            {
-                Properties props = new Properties();
-                props.load(input);
-                version = props.getProperty("version", "Unknown");
-            }
-        }
-        catch (IOException ignored)
-        {
-        }
-        PLUGIN_VERSION = version;
+        PLUGIN_VERSION = PluginVersionUtility.get();
 
         final BufferedImage arrowRight = ImageUtil.loadImageResource(QuestVoiceoverPanel.class, "arrow_right.png");
         ARROW_RIGHT_ICON = new ImageIcon(arrowRight);
@@ -54,6 +56,8 @@ public class QuestVoiceoverPanel extends PluginPanel
 
         final BufferedImage discordIcon = ImageUtil.loadImageResource(QuestVoiceoverPanel.class, "discord_icon.png");
         DISCORD_ICON = new ImageIcon(discordIcon);
+
+        DONATION_ICON = createHeartIcon();
     }
 
     private final JLabel databaseVersionLabel;
@@ -166,6 +170,8 @@ public class QuestVoiceoverPanel extends PluginPanel
         add(buildLinkPanel(GITHUB_ICON, "Report an issue or", "make a suggestion", REPORT_ISSUE_URL));
         add(Box.createVerticalStrut(10));
         add(buildLinkPanel(DISCORD_ICON, "Talk to us on our", "Discord server", DISCORD_URL));
+        add(Box.createVerticalStrut(10));
+        add(buildLinkPanel(DONATION_ICON, "Support the plugin", "on Ko-fi", KOFI_URL));
         add(Box.createVerticalGlue());
     }
 
@@ -191,6 +197,36 @@ public class QuestVoiceoverPanel extends PluginPanel
     private static String htmlLabel(String key, String value)
     {
         return "<html><body>" + key + "<span style='color:white'>" + value + "</span></body></html>";
+    }
+
+    /**
+     * Drawn at runtime rather than shipped as an asset so the donation button needs no
+     * bundled image and carries no third-party logo/trademark.
+     */
+    private static ImageIcon createHeartIcon()
+    {
+        BufferedImage image = new BufferedImage(ICON_SIZE, ICON_SIZE, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        graphics.setColor(KOFI_RED);
+
+        double lobeDiameter = HEART_LOBE_RADIUS * 2;
+        graphics.fill(new Ellipse2D.Double(
+            HEART_LEFT_LOBE_CENTER_X - HEART_LOBE_RADIUS, HEART_LOBE_CENTER_Y - HEART_LOBE_RADIUS,
+            lobeDiameter, lobeDiameter));
+        graphics.fill(new Ellipse2D.Double(
+            HEART_RIGHT_LOBE_CENTER_X - HEART_LOBE_RADIUS, HEART_LOBE_CENTER_Y - HEART_LOBE_RADIUS,
+            lobeDiameter, lobeDiameter));
+
+        Path2D.Double body = new Path2D.Double();
+        body.moveTo(HEART_BODY_TOP_LEFT_X, HEART_BODY_TOP_Y);
+        body.lineTo(HEART_BODY_TOP_RIGHT_X, HEART_BODY_TOP_Y);
+        body.lineTo(HEART_BODY_TIP_X, HEART_BODY_TIP_Y);
+        body.closePath();
+        graphics.fill(body);
+
+        graphics.dispose();
+        return new ImageIcon(image);
     }
 
     private static JPanel buildLinkPanel(ImageIcon icon, String topText, String bottomText, String url)

--- a/src/main/java/com/quest/voiceover/QuestVoiceoverPlugin.java
+++ b/src/main/java/com/quest/voiceover/QuestVoiceoverPlugin.java
@@ -1,6 +1,7 @@
 package com.quest.voiceover;
 
 import com.google.inject.Provides;
+import com.quest.voiceover.features.ChangelogHandler;
 import com.quest.voiceover.features.QuestListIndicatorHandler;
 import com.quest.voiceover.features.voiceover.overlay.VoiceoverOverlayHandler;
 import com.quest.voiceover.features.voiceover.overlay.VoiceoverOverlayMouseListener;
@@ -13,6 +14,7 @@ import com.quest.voiceover.modules.dialog.DialogManager;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.events.*;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.client.config.ConfigManager;
@@ -59,6 +61,9 @@ public class QuestVoiceoverPlugin extends Plugin {
 
     @Inject
     private QuestListIndicatorHandler questListIndicatorHandler;
+
+    @Inject
+    private ChangelogHandler changelogHandler;
 
     @Inject
     private DialogManager dialogManager;
@@ -149,6 +154,13 @@ public class QuestVoiceoverPlugin extends Plugin {
 
         if (event.getGroupId() == InterfaceID.QUEST_LIST) {
             questListIndicatorHandler.onQuestListClosed();
+        }
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged event) {
+        if (event.getGameState() == GameState.LOGGED_IN) {
+            changelogHandler.checkForUpdate();
         }
     }
 

--- a/src/main/java/com/quest/voiceover/features/ChangelogHandler.java
+++ b/src/main/java/com/quest/voiceover/features/ChangelogHandler.java
@@ -1,0 +1,145 @@
+package com.quest.voiceover.features;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.quest.voiceover.Constants;
+import com.quest.voiceover.utility.PluginVersionUtility;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.Client;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.ConfigManager;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Slf4j
+@Singleton
+public class ChangelogHandler {
+
+    private static final String LAST_SEEN_VERSION_KEY = "lastSeenVersion";
+    private static final String RELEASE_NOTES_API_URL =
+        "https://api.github.com/repos/KevinEdry/runelite-quest-voiceover/releases/tags/v";
+    private static final String CHAT_PREFIX = "[Quest Voiceover] ";
+    private static final int MAX_CHANGELOG_LINES = 20;
+
+    @Inject
+    private Client client;
+
+    @Inject
+    private ClientThread clientThread;
+
+    @Inject
+    private ConfigManager configManager;
+
+    @Inject
+    private OkHttpClient okHttpClient;
+
+    @Inject
+    private ScheduledExecutorService executor;
+
+    private boolean checkedThisSession;
+
+    /**
+     * The changelog must appear once per new release rather than on every login.
+     */
+    public void checkForUpdate() {
+        if (checkedThisSession) {
+            return;
+        }
+        checkedThisSession = true;
+
+        if (!PluginVersionUtility.isKnown()) {
+            return;
+        }
+
+        String currentVersion = PluginVersionUtility.get();
+        String lastSeenVersion = configManager.getConfiguration(Constants.PLUGIN_CONFIG_GROUP, LAST_SEEN_VERSION_KEY);
+
+        configManager.setConfiguration(Constants.PLUGIN_CONFIG_GROUP, LAST_SEEN_VERSION_KEY, currentVersion);
+
+        boolean freshInstall = lastSeenVersion == null || lastSeenVersion.isEmpty();
+        if (freshInstall || currentVersion.equals(lastSeenVersion)) {
+            return;
+        }
+
+        executor.submit(() -> fetchAndDisplayChangelog(currentVersion));
+    }
+
+    private void fetchAndDisplayChangelog(String version) {
+        Request request = new Request.Builder()
+            .url(RELEASE_NOTES_API_URL + version)
+            .header("Accept", "application/vnd.github+json")
+            .build();
+
+        try (Response response = okHttpClient.newCall(request).execute()) {
+            if (!response.isSuccessful() || response.body() == null) {
+                log.warn("Failed to fetch release notes for v{}: HTTP {}", version, response.code());
+                return;
+            }
+
+            JsonObject release = new JsonParser().parse(response.body().string()).getAsJsonObject();
+            JsonElement notes = release.get("body");
+            if (notes == null || notes.isJsonNull()) {
+                return;
+            }
+
+            List<String> lines = formatReleaseNotes(notes.getAsString());
+            if (lines.isEmpty()) {
+                return;
+            }
+
+            displayInChat(version, lines);
+        } catch (IOException e) {
+            log.warn("Error fetching release notes for v{}", version, e);
+        }
+    }
+
+    private void displayInChat(String version, List<String> lines) {
+        clientThread.invoke(() -> {
+            client.addChatMessage(ChatMessageType.GAMEMESSAGE, "",
+                CHAT_PREFIX + "Updated to v" + version + " - here's what's new:", null);
+            for (String line : lines) {
+                client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", line, null);
+            }
+        });
+    }
+
+    private List<String> formatReleaseNotes(String body) {
+        List<String> lines = new ArrayList<>();
+
+        for (String rawLine : body.split("\\r?\\n")) {
+            if (lines.size() >= MAX_CHANGELOG_LINES) {
+                lines.add(" ...");
+                break;
+            }
+
+            String line = rawLine.trim();
+            if (line.startsWith("###")) {
+                lines.add(stripMarkdown(line.replaceFirst("^#+\\s*", "")) + ":");
+            } else if (line.startsWith("*") || line.startsWith("-")) {
+                String text = stripMarkdown(line.replaceFirst("^[*-]\\s*", ""));
+                if (!text.isEmpty()) {
+                    lines.add(" - " + text);
+                }
+            }
+        }
+
+        return lines;
+    }
+
+    private String stripMarkdown(String text) {
+        text = text.replaceAll("\\[([^\\]]+)\\]\\([^)]*\\)", "$1");
+        text = text.replaceAll("\\s*\\([0-9a-f]{7,40}\\)", "");
+        text = text.replace("**", "").replace("`", "");
+        return text.trim();
+    }
+}

--- a/src/main/java/com/quest/voiceover/utility/PluginVersionUtility.java
+++ b/src/main/java/com/quest/voiceover/utility/PluginVersionUtility.java
@@ -1,0 +1,35 @@
+package com.quest.voiceover.utility;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public final class PluginVersionUtility {
+
+    private static final String VERSION_RESOURCE = "/com/quest/voiceover/version.properties";
+    private static final String UNKNOWN_VERSION = "Unknown";
+
+    private static final String VERSION = load();
+
+    private PluginVersionUtility() {}
+
+    public static String get() {
+        return VERSION;
+    }
+
+    public static boolean isKnown() {
+        return !UNKNOWN_VERSION.equals(VERSION);
+    }
+
+    private static String load() {
+        try (InputStream input = PluginVersionUtility.class.getResourceAsStream(VERSION_RESOURCE)) {
+            if (input != null) {
+                Properties props = new Properties();
+                props.load(input);
+                return props.getProperty("version", UNKNOWN_VERSION);
+            }
+        } catch (IOException ignored) {
+        }
+        return UNKNOWN_VERSION;
+    }
+}


### PR DESCRIPTION
Adds two panel/UX features.

## Ko-fi donation button
A **Support the plugin on Ko-fi** button (→ https://ko-fi.com/kedry) in the plugin panel, below the Discord link. It reuses the existing `buildLinkPanel(...)` layout. The heart icon is drawn at runtime (`createHeartIcon()`) from named geometry constants, so nothing extra is bundled and no third-party logo/trademark is used.

## Changelog chat message on update
On login, the plugin prints the release notes for the running version into the chat box — but **only once per new release**:

- A persisted `lastSeenVersion` config key is compared against the running version. It's written *before* display, so a failed/partial fetch never re-triggers on the next login.
- **Fresh installs are silent** (no prior version recorded) so existing players aren't greeted with a changelog they didn't update into.
- Notes are fetched async off the client thread from `GET /releases/tags/v{version}`, then formatted: markdown links collapsed to their label, release-please commit-hash parentheticals removed, `**`/backticks stripped, section headings + bullets kept, capped at 20 lines.

Example output (verified against the live GitHub API):
```
[Quest Voiceover] Updated to v1.13.0 - here's what's new:
Features:
 - add player dialog toggle and finish-last-line option, closes #158
 - panel: add Ko-fi donation button
Bug Fixes:
 - recover database connection after disconnect
```

## Supporting change
- `utility/PluginVersionUtility.java` centralizes reading `version.properties`; the panel now uses it instead of its own inline loader.

## Verification
- Compiles under Java 11 (`./gradlew compileJava`).
- Changelog fetch + formatting exercised against the real GitHub Releases API; heart icon rendered and visually checked. (Full in-client login flow not run headlessly.)