### PR TITLE
perf(git): use Git Trees + raw reads to stop exhausting the REST rate limit

### DIFF
--- a/windmill/f/quest_voiceover/list_quests.bun.ts
+++ b/windmill/f/quest_voiceover/list_quests.bun.ts
@@ -7,8 +7,9 @@ export interface QuestOption {
   label: string;
 }
 
-// Reads run in parallel batches: this backs a dropdown, so ~200 sequential transcript
-// fetches would take too long for the field to populate.
+// Transcript bodies are read from raw.githubusercontent.com in parallel batches: this backs
+// a dropdown, so ~200 sequential fetches would be too slow, and raw reads (unlike the
+// Contents API) don't draw down the REST rate limit.
 const READ_CONCURRENCY = 30;
 
 export async function main(
@@ -26,14 +27,14 @@ export async function main(
   dialogs.database.close();
   dialogs.cleanup();
 
-  const files = (await github.listDirectory(transcriptsPath, transcriptsBranch)).filter((file) =>
-    file.endsWith(".json")
+  const files = [...(await github.listBranchFiles(transcriptsBranch))].filter(
+    (file) => file.startsWith(`${transcriptsPath}/`) && file.endsWith(".json")
   );
 
   const readQuest = async (file: string) => {
-    const found = await github.getFile(file, transcriptsBranch);
-    if (!found) return null;
-    const questName = (JSON.parse(found.content.toString("utf-8")) as { quest_name: string }).quest_name;
+    const content = await github.getRawFile(file, transcriptsBranch);
+    if (!content) return null;
+    const questName = (JSON.parse(content.toString("utf-8")) as { quest_name: string }).quest_name;
     return { value: file, questName, generated: voiced.has(questName) };
   };
 

--- a/windmill/f/quest_voiceover/plan_generation.bun.ts
+++ b/windmill/f/quest_voiceover/plan_generation.bun.ts
@@ -83,17 +83,15 @@ export async function main(
 
   // A clip already on the branch it would commit to is skipped, so it doesn't count toward
   // cost — this makes a re-run/resume show only what's left rather than the whole quest.
+  // One recursive tree listing replaces a Contents API request per clip, which on a large
+  // quest exhausted the REST rate limit.
   const branch = featureBranch.length > 0 ? featureBranch : soundsBranch;
+  const present = await github.listBranchFiles(branch);
   let alreadyGenerated = 0;
   let estimatedCharacters = 0;
-  const CONCURRENCY = 40;
-  for (let i = 0; i < targets.length; i += CONCURRENCY) {
-    const batch = targets.slice(i, i + CONCURRENCY);
-    const present = await Promise.all(batch.map((t) => github.checkAudioFileExists(t.hash, branch)));
-    batch.forEach((t, index) => {
-      if (present[index]) alreadyGenerated++;
-      else estimatedCharacters += t.chars;
-    });
+  for (const target of targets) {
+    if (present.has(`${target.hash}.mp3`)) alreadyGenerated++;
+    else estimatedCharacters += target.chars;
   }
   const clipsToGenerate = targets.length - alreadyGenerated;
   const estimatedCostUsd = Math.round((estimatedCharacters / 1000) * costPer1kCharacters * 100) / 100;

--- a/windmill/f/tools/git.bun.ts
+++ b/windmill/f/tools/git.bun.ts
@@ -17,10 +17,12 @@ export interface UploadAudioInput {
 
 export interface GitHubClient {
   readonly getFile: (path: string, branch: string) => Promise<{ content: Buffer; sha: string } | null>;
+  readonly getRawFile: (path: string, branch: string) => Promise<Buffer | null>;
   readonly fileExists: (path: string, branch: string) => Promise<boolean>;
   readonly createOrUpdateFile: (path: string, content: Buffer, branch: string, message: string) => Promise<void>;
   readonly uploadAudioFile: (input: UploadAudioInput) => Promise<string>;
   readonly checkAudioFileExists: (hash: string, soundsBranch: string) => Promise<boolean>;
+  readonly listBranchFiles: (branch: string) => Promise<Set<string>>;
   readonly getFileSha: (path: string, branch: string) => Promise<string | null>;
   readonly listDirectory: (path: string, branch: string) => Promise<string[]>;
   readonly branchExists: (branchName: string) => Promise<boolean>;
@@ -64,6 +66,17 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
     }
   };
 
+  // Reads straight from raw.githubusercontent.com (public repo, unauthenticated) so bulk
+  // reads don't draw down the 5,000/hour REST budget. Not for the database: raw is
+  // CDN-cached for a few minutes and the DB read must reflect the latest committed rows.
+  const getRawFile = async (path: string, branch: string): Promise<Buffer | null> => {
+    const rawUrl = `https://raw.githubusercontent.com/${config.owner}/${config.repo}/${branch}/${path}`;
+    const response = await fetch(rawUrl);
+    if (response.status === 404) return null;
+    if (!response.ok) throw new Error(`Failed to fetch raw file ${path}: ${response.status}`);
+    return Buffer.from(await response.arrayBuffer());
+  };
+
   const createOrUpdateFile = async (
     path: string,
     content: Buffer,
@@ -91,8 +104,38 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
     return filename;
   };
 
-  const checkAudioFileExists = async (hash: string, soundsBranch: string): Promise<boolean> =>
-    fileExists(`${hash}.mp3`, soundsBranch);
+  // A raw.githubusercontent.com HEAD rather than a Contents API request: the resume path
+  // checks one clip per generated line, which on a large quest would exhaust the REST rate
+  // limit — raw has its own, far higher budget.
+  const checkAudioFileExists = async (hash: string, soundsBranch: string): Promise<boolean> => {
+    const rawUrl = `https://raw.githubusercontent.com/${config.owner}/${config.repo}/${soundsBranch}/${hash}.mp3`;
+    const response = await fetch(rawUrl, { method: "HEAD" });
+    if (response.status === 404) return false;
+    if (!response.ok) throw new Error(`Failed to check ${hash}.mp3: ${response.status}`);
+    return true;
+  };
+
+  // A single recursive Git Trees request lists every path on a branch, so callers test
+  // existence in memory instead of a Contents API request per file. The pre-generation
+  // estimate checks thousands of clips and would otherwise blow the REST rate limit.
+  const listBranchFiles = async (branch: string): Promise<Set<string>> => {
+    try {
+      const tree = await withRetry(() =>
+        octokit.git.getTree({ owner: config.owner, repo: config.repo, tree_sha: branch, recursive: "true" })
+      );
+      if (tree.data.truncated) {
+        throw new Error(`Tree for ${branch} exceeds the single-request limit; existence checks would be incomplete`);
+      }
+      return new Set(
+        tree.data.tree
+          .filter((entry) => entry.type === "blob" && typeof entry.path === "string")
+          .map((entry) => entry.path as string)
+      );
+    } catch (error: unknown) {
+      if (extractStatus(error) === 404) return new Set();
+      throw error;
+    }
+  };
 
   // Identical content yields the same blob sha across branches, so callers compare shas
   // to detect whether a file differs from a baseline without downloading it.
@@ -140,10 +183,12 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
 
   return {
     getFile,
+    getRawFile,
     fileExists,
     createOrUpdateFile,
     uploadAudioFile,
     checkAudioFileExists,
+    listBranchFiles,
     getFileSha,
     listDirectory,
     branchExists,


### PR DESCRIPTION
## Problem

The pipeline drove the GitHub **Contents API one request per file**, which burns the 5,000/hour REST budget and 403s mid-run (as happened during `cleanup_voices`):

- **`plan_generation`** checked each clip's existence with `checkAudioFileExists` in batches of 40 — a large quest fires **thousands** of requests just to build the cost estimate.
- **`list_quests`** read every transcript via the Contents API on **each dropdown render** (~200 requests).
- The per-line **resume** check hit the Contents API once per generated clip.

## Changes

- **`git.bun.ts`**
  - `listBranchFiles(branch)` — one recursive **Git Trees** request returns every path on a branch as an in-memory `Set` (guards against the truncation limit; treats a missing branch as empty).
  - `getRawFile(path, branch)` — reads from `raw.githubusercontent.com`, which has its own far higher budget and doesn't touch the REST limit.
  - `checkAudioFileExists` — now a raw `HEAD`.
- **`plan_generation.bun.ts`** — one `listBranchFiles` call + set membership instead of a Contents API request per clip.
- **`list_quests.bun.ts`** — file list from the tree; transcript bodies via `getRawFile`.

Net: a full plan + estimate drops from **thousands** of REST calls to **~1**.

## Deliberately unchanged

The **database read stays on the Contents API** — `raw` is CDN-cached for a few minutes, and the DB read must reflect the latest committed rows (stale reads are exactly what caused the parallel-write data loss fixed in #175).

## Note

Windmill lock/metadata files aren't regenerated here; they'll refresh on `wmill generate-metadata` / deploy.