### PR TITLE
feat(pipeline): write per-quest DB row shards instead of the binary blob

### DIFF
--- a/windmill/f/quest_voiceover/expand_targets.bun.ts
+++ b/windmill/f/quest_voiceover/expand_targets.bun.ts
@@ -1,6 +1,7 @@
 import * as wmill from "windmill-client";
 import {
   createGitHubClient,
+  slugifyQuest,
   type DialogLine,
   type GenerationTarget,
   type VoiceMap,
@@ -9,14 +10,6 @@ import {
 export interface PrepareQuestResult {
   featureBranch: string;
   targets: GenerationTarget[];
-}
-
-function slugify(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
 }
 
 export async function main(
@@ -51,7 +44,7 @@ export async function main(
 
   const now = new Date().toISOString();
   const timestamp = `${now.slice(0, 10).replace(/-/g, "")}-${now.slice(11, 19).replace(/:/g, "")}`;
-  const branch = featureBranch || `voiceover-${slugify(questName)}-${timestamp}`;
+  const branch = featureBranch || `voiceover-${slugifyQuest(questName)}-${timestamp}`;
   if (await github.branchExists(branch)) {
     console.log(`Feature branch ${branch} already exists, reusing it`);
   } else {

--- a/windmill/f/quest_voiceover/write_database.bun.ts
+++ b/windmill/f/quest_voiceover/write_database.bun.ts
@@ -1,6 +1,6 @@
 import * as wmill from "windmill-client";
 import { createGitHubClient } from "../tools/git";
-import { openDialogsDatabase } from "../tools/database";
+import { slugifyQuest } from "../tools/text";
 import type { LineResult } from "../tools/types";
 
 export interface QuestSummary {
@@ -9,8 +9,15 @@ export interface QuestSummary {
   completed: number;
   skipped: number;
   failed: number;
-  inserted: number;
+  rows: number;
   databaseFeatureBranch: string | null;
+}
+
+interface DialogRow {
+  quest: string;
+  character: string;
+  text: string;
+  uri: string;
 }
 
 export async function main(
@@ -22,43 +29,51 @@ export async function main(
   databaseBranch = "database",
   dryRun = false
 ): Promise<QuestSummary> {
-  const githubToken = await wmill.getVariable("f/quest_voiceover/github_token");
-  const github = createGitHubClient({ token: githubToken, owner: githubOwner, repo: githubRepo });
-
-  const dialogs = await openDialogsDatabase(github, databaseBranch);
-
-  let inserted = 0;
-  for (const result of results) {
-    if (!result || result.status === "failed" || !result.uri) continue;
-    if (dialogs.insert({ quest: questName, character: result.character, text: result.text, uri: result.uri })) {
-      inserted++;
-    }
-  }
-
   const completed = results.filter((r) => r?.status === "completed").length;
   const skipped = results.filter((r) => r?.status === "skipped").length;
   const failed = results.filter((r) => r?.status === "failed").length;
-  const databaseFeatureBranch = `${featureBranch}-db`;
 
-  const summary = { questName, totalTargets: results.length, completed, skipped, failed, inserted };
+  // Every clip that exists (generated now or skipped because already present) is a row;
+  // failed clips have no audio so they are left out. Skipped clips carry their uri, so a
+  // resume still writes the quest's complete row set, not just this run's new clips.
+  const byKey = new Map<string, DialogRow>();
+  for (const result of results) {
+    if (!result || result.status === "failed" || !result.uri) continue;
+    const row: DialogRow = { quest: questName, character: result.character, text: result.text, uri: result.uri };
+    byKey.set(JSON.stringify([row.character, row.text, row.uri]), row);
+  }
+  const rows = [...byKey.values()].sort(
+    (a, b) => a.character.localeCompare(b.character) || a.text.localeCompare(b.text) || a.uri.localeCompare(b.uri)
+  );
+
+  const databaseFeatureBranch = `${featureBranch}-db`;
+  const shardPath = `db/rows/${slugifyQuest(questName)}.jsonl`;
+  const summary = { questName, totalTargets: results.length, completed, skipped, failed, rows: rows.length };
 
   if (dryRun) {
-    console.log(`[DRY RUN] Would write ${inserted} rows to ${databaseFeatureBranch}`);
-    dialogs.database.close();
-    dialogs.cleanup();
+    console.log(`[DRY RUN] Would write ${rows.length} rows to ${shardPath} on ${databaseFeatureBranch}`);
     return { ...summary, databaseFeatureBranch };
   }
 
-  if (inserted === 0) {
-    dialogs.database.close();
-    dialogs.cleanup();
-    return { ...summary, databaseFeatureBranch: null };
-  }
+  if (rows.length === 0) return { ...summary, databaseFeatureBranch: null };
+
+  const githubToken = await wmill.getVariable("f/quest_voiceover/github_token");
+  const github = createGitHubClient({ token: githubToken, owner: githubOwner, repo: githubRepo });
 
   if (!(await github.branchExists(databaseFeatureBranch))) {
     await github.createBranch(databaseFeatureBranch, databaseBranch);
   }
-  await dialogs.save(databaseFeatureBranch, `feat: Add ${inserted} dialog rows for ${questName}`);
+
+  // A whole-quest shard under a distinct filename: parallel quests never collide (unlike the
+  // old single binary .db), and re-running a quest overwrites only its own shard. The .db the
+  // plugin downloads is rebuilt from all shards by the database branch's rebuild workflow.
+  const content = rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+  await github.createOrUpdateFile(
+    shardPath,
+    Buffer.from(content, "utf-8"),
+    databaseFeatureBranch,
+    `feat: Add ${rows.length} dialog rows for ${questName}`
+  );
 
   return { ...summary, databaseFeatureBranch };
 }

--- a/windmill/f/tools/text.bun.ts
+++ b/windmill/f/tools/text.bun.ts
@@ -23,3 +23,13 @@ export function removeSpecialCharacters(line: string): string {
 export function generateDialogHash(character: string, line: string): string {
   return createHash("md5").update(`${character}|${line}`).digest("hex");
 }
+
+// Stable per-quest slug shared by the feature-branch name and the db/rows/<slug>.jsonl
+// shard, so re-running a quest overwrites its own shard rather than creating a second one.
+export function slugifyQuest(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+}


### PR DESCRIPTION
Pairs with #186 (database branch) to fix the parallel-write data loss at its root.

## Change

`write_database` no longer downloads, mutates, and re-commits the whole `quest_voiceover_v2.db`. It now writes **one shard per quest** — `db/rows/<slug>.jsonl` — to the `<feature>-db` branch:

- Distinct filename per quest ⇒ parallel quest branches **merge cleanly** (the blob couldn't); a re-run overwrites only that quest's shard, so no duplicate rows.
- **Resume-safe:** skipped clips carry their `uri`, so `results` is the quest's complete existing-clip set — the shard is complete, not just this run's new clips.
- The `.db` the plugin downloads is rebuilt from all shards by the rebuild workflow added in #186.

## Files
- `text.bun.ts` — add shared `slugifyQuest` (used by both the feature-branch name and the shard path, so they always agree).
- `expand_targets.bun.ts` — use the shared `slugifyQuest` (was a local copy).
- `write_database.bun.ts` — emit `db/rows/<slug>.jsonl`; drops the `openDialogsDatabase`/`bun:sqlite` path entirely.

Same step signature — no `flow.yaml` rewiring. The summary field `inserted` is renamed to `rows`.

## Merge together with #186
Merge this with #186 so the Action becomes the single writer of the `.db`. After both land, the next generated quest lands as a shard and the Action rebuilds the blob.

_Windmill lock/metadata not regenerated here; refreshes on `wmill generate-metadata` / deploy._