### PR TITLE
feat(quest_voiceover): open PRs to sounds and database at the end of a run

### DIFF
--- a/windmill/f/quest_voiceover/open_pull_requests.bun.ts
+++ b/windmill/f/quest_voiceover/open_pull_requests.bun.ts
@@ -1,0 +1,50 @@
+import * as wmill from "windmill-client";
+import { createGitHubClient } from "../tools/git";
+
+export interface OpenedPullRequests {
+  soundsPullRequest: string | null;
+  databasePullRequest: string | null;
+}
+
+export async function main(
+  questName: string,
+  featureBranch: string,
+  databaseFeatureBranch: string | null,
+  githubOwner: string,
+  githubRepo: string,
+  soundsBranch = "sounds",
+  databaseBranch = "database",
+  dryRun = false
+): Promise<OpenedPullRequests> {
+  if (dryRun) {
+    console.log(
+      `[DRY RUN] Would open PRs: ${featureBranch} -> ${soundsBranch}` +
+        (databaseFeatureBranch ? ` and ${databaseFeatureBranch} -> ${databaseBranch}` : "")
+    );
+    return { soundsPullRequest: null, databasePullRequest: null };
+  }
+
+  const githubToken = await wmill.getVariable("f/quest_voiceover/github_token");
+  const github = createGitHubClient({ token: githubToken, owner: githubOwner, repo: githubRepo });
+
+  const audio = await github.createPullRequest({
+    head: featureBranch,
+    base: soundsBranch,
+    title: `feat(sounds): ${questName} voice lines`,
+    body: `Generated voice-line audio for **${questName}**, produced by the quest voiceover pipeline.`,
+  });
+
+  // Only when write_database wrote a shard branch (a dry run or a quest with no new rows
+  // leaves databaseFeatureBranch null).
+  const database = databaseFeatureBranch
+    ? await github.createPullRequest({
+        head: databaseFeatureBranch,
+        base: databaseBranch,
+        title: `feat(db): ${questName} dialog rows`,
+        body: `Dialog row shard for **${questName}**. The database branch's workflow rebuilds quest_voiceover_v2.db from all shards on merge.`,
+      })
+    : null;
+
+  console.log(`sounds PR: ${audio?.url ?? "none"} | database PR: ${database?.url ?? "none"}`);
+  return { soundsPullRequest: audio?.url ?? null, databasePullRequest: database?.url ?? null };
+}

--- a/windmill/f/quest_voiceover/quest_voiceover.flow/flow.yaml
+++ b/windmill/f/quest_voiceover/quest_voiceover.flow/flow.yaml
@@ -5,9 +5,10 @@ description: >-
   previews the plan — voices to create, the character/voice breakdown, and the estimated
   ElevenLabs characters and cost — and pauses for approval. On approval it matches/creates the
   voices, fans each dialog line into per-voice targets (Player fans out to Player Male + Female),
-  commits the audio to a feature branch off sounds (one commit per line), and writes the new
-  dialog rows to a matching feature branch off the database branch. Set dryRun to synthesise
-  without committing; set resume + the existing featureBranch to continue an interrupted run.
+  commits the audio to a feature branch off sounds (one commit per line), writes the new
+  dialog rows to a matching feature branch off the database branch, and opens a pull request
+  for each (audio to sounds, rows to database). Set dryRun to synthesise without committing;
+  set resume + the existing featureBranch to continue an interrupted run.
 value:
   modules:
     - id: load_transcript
@@ -203,6 +204,36 @@ value:
             type: javascript
             expr: flow_input.dryRun
         path: f/quest_voiceover/write_database
+    - id: open_pull_requests
+      summary: Open PRs to sounds + database
+      value:
+        type: script
+        input_transforms:
+          questName:
+            type: javascript
+            expr: results.load_transcript.questName
+          featureBranch:
+            type: javascript
+            expr: results.expand_targets.featureBranch
+          databaseFeatureBranch:
+            type: javascript
+            expr: results.write_db.databaseFeatureBranch
+          githubOwner:
+            type: javascript
+            expr: flow_input.githubOwner
+          githubRepo:
+            type: javascript
+            expr: flow_input.githubRepo
+          soundsBranch:
+            type: javascript
+            expr: flow_input.soundsBranch
+          databaseBranch:
+            type: javascript
+            expr: flow_input.databaseBranch
+          dryRun:
+            type: javascript
+            expr: flow_input.dryRun
+        path: f/quest_voiceover/open_pull_requests
 schema:
   $schema: https://json-schema.org/draft/2020-12/schema
   type: object

--- a/windmill/f/tools/git.bun.ts
+++ b/windmill/f/tools/git.bun.ts
@@ -25,6 +25,14 @@ export interface GitHubClient {
   readonly listDirectory: (path: string, branch: string) => Promise<string[]>;
   readonly branchExists: (branchName: string) => Promise<boolean>;
   readonly createBranch: (branchName: string, sourceBranch: string) => Promise<void>;
+  readonly createPullRequest: (input: PullRequestInput) => Promise<{ url: string; number: number } | null>;
+}
+
+export interface PullRequestInput {
+  readonly head: string;
+  readonly base: string;
+  readonly title: string;
+  readonly body: string;
 }
 
 export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
@@ -138,6 +146,37 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
     console.log(`Created branch ${branchName} from ${sourceBranch}`);
   };
 
+  // Idempotent: a resume run re-opening the same head/base returns the already-open PR
+  // instead of failing, and a head with no new commits yields null rather than throwing.
+  const createPullRequest = async (
+    input: PullRequestInput
+  ): Promise<{ url: string; number: number } | null> => {
+    try {
+      const created = await withRetry(() =>
+        octokit.pulls.create({
+          owner: config.owner,
+          repo: config.repo,
+          head: input.head,
+          base: input.base,
+          title: input.title,
+          body: input.body,
+        })
+      );
+      return { url: created.data.html_url, number: created.data.number };
+    } catch (error: unknown) {
+      if (extractStatus(error) !== 422) throw error;
+      const existing = await octokit.pulls.list({
+        owner: config.owner,
+        repo: config.repo,
+        head: `${config.owner}:${input.head}`,
+        base: input.base,
+        state: "open",
+      });
+      const open = existing.data[0];
+      return open ? { url: open.html_url, number: open.number } : null;
+    }
+  };
+
   return {
     getFile,
     fileExists,
@@ -148,5 +187,6 @@ export function createGitHubClient(config: GitHubClientConfig): GitHubClient {
     listDirectory,
     branchExists,
     createBranch,
+    createPullRequest,
   };
 }


### PR DESCRIPTION
The quest generator now opens both pull requests automatically at the end of a run, instead of you creating them by hand.

## Change
- **`git.bun.ts`** — `createPullRequest(head, base, title, body)`. Idempotent: a resume run that re-opens the same head/base returns the already-open PR (handles the 422), and a head with no new commits returns `null` rather than throwing.
- **`open_pull_requests.bun.ts`** — new final step. Opens the audio feature branch → `sounds` and the `<feature>-db` branch → `database`. Skips the database PR when `write_db` wrote nothing (`databaseFeatureBranch` null), and no-ops under `dryRun`.
- **`flow.yaml`** — wires the step after `write_db`; updates the flow description.

## Notes
- Orthogonal to #187 (shard write): this only PRs whatever `write_db` produced, blob or shard.
- Touches `git.bun.ts`, which #185 also edits (different regions — a trivial conflict for whichever merges second).
- Windmill lock/metadata for the new `open_pull_requests` script refreshes on `wmill generate-metadata` / deploy.