### PR TITLE
feat(db): Vale Totems dialog rows

### DIFF
--- a/db/rows/vale-totems-miniquest.jsonl
+++ b/db/rows/vale-totems-miniquest.jsonl
@@ -1,0 +1,105 @@
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"But you won't be able to do it without a knife! Here!","uri":"e06a54db843c96e10b1a782579c9b743.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"But you won't be able to do it without a knife! Make some space and I'll give you one!","uri":"0b59e1eefb4bc4dbc822b989be001271.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Excuse me? I have a name! I'm Isadora, and you're the funny man who gets confused by the ents! I've been watching you.","uri":"fc1d746b5ec0cb173aeccd77da830202.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Funny man Ranulph broke the totem! Ents won't be happy with you!","uri":"17cd26f592379e15189a8b6838bf3a89.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Funny man Ranulph is learning!","uri":"1518df4cbeddb37d7c0fd52358960bf8.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Goddbye, other funny person. You did great!","uri":"55f808aeb9c5856d79e2e11fc29bb971.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Have you carved the animals yet?","uri":"1799e1890fcac27752dc37c779c517ad.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Hurry up! You don't want the ents to stay sad, do you?","uri":"44807485476d6ba211baedc039c9c68d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"It's a gift! The ents are happy again! They're saying thank you for helping! Go on, take it!","uri":"c349a9ce5425c031221c7b7ee71bdbc3.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"It's okay, funny man. The totems always end up breaking. The ents get sad for a while, but if you fix them, they end up all happy again!","uri":"14de8fc7d7ad30d4af9ebd44e7957910.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Meaning you need to carve the right ones, silly.","uri":"10ddc596bd8d2fe35b5818b5143d0174.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Notes? Notes are boring! I know how to carve them! Daddy showed me!","uri":"b356c06b85372333b9be931555c34075.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Now you need to carve the animals!","uri":"33968fc4b3d6c04c8e5292e6c394e0f5.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Thanks, funny man Ranulph. You're not so bad yourself!","uri":"f41acce9793b14848123be11ef56c498.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"That's not right!","uri":"39b05d2ad539290b3754f46d6c97b7af.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Uh oh! The funny man broke the totem!","uri":"3af0f9dfc057809932d28d3740e893ed.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Yes! The ents like it when you help! They'll give you more gifts!","uri":"31133190d2a6a6f930f97a2de0094d17.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"Yes! You need to help them finish the cycle!","uri":"1823a8f05274cd385d47eeb92ca7ddc6.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"You did a good job! Now we have to see if you've made the ents happy again!","uri":"41258bcd12657a42737999e61cc8abe6.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Isadora","text":"You need to use the wooden things. Bows! Shields!","uri":"448d348c7d2055a9d67abc2b2381dfc2.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Ah, sorry to have disturbed you then.","uri":"3ab37f7aa265483eb2d6efcf363393d7.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Any specific type?","uri":"cfedf0eb9ea738230de5c0ed2cef7dad.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Cycle?","uri":"ee6c14d213eb18ba738b10c03410fcc1.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Does something have you preoccupied?","uri":"a66510b812d69bc932d3df2fac1a81b1.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Have you asked around?","uri":"dc0cc656de01d0d7855647b98734ed6d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Hello again. If you don't mind me saying, you seem quite preoccupied.","uri":"a9035daf37cd37fca769c19480383226.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Hello.","uri":"dc53029f6d2c3bb5144a3d14e4bf3650.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Hmm... Well, why don't we take a closer look at this totem?","uri":"07cd3ffc27479e2d9613d7c24882be5c.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"I supposed that makes sense. I'll give it a go.","uri":"f05dd0ab02408f7d213530473184f3a1.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"I'm not sure 'we' is the right word...","uri":"3b3cb9d2370f80c24c8be09f8f84409d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"I'm still working on it.","uri":"dcf04c7d082ec27a926baf5d470a2f3d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Interesting... It's like some sort of ritual.","uri":"733732e49e5655c36b0f4bdad581841d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"It's a beautiful totem.","uri":"a98523089ad5c7b5cacb76be83755d7e.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Meaning?","uri":"0a1a7eebfcd93eebc1e34c68c5b67cda.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Okay then. So wooden items? You mean things like bows and shields?","uri":"9308eef8c35ea41da4e0c381c083f8df.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Okay, I'll be back once I've done that.","uri":"0a454eed167deac24bb8c6bbdd2166c9.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Or survive interference from... you know... us.","uri":"b7fb7d9fa255192264fe1a468952d16c.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"So we need to fix the totem. How?","uri":"339e510cda409ab8f42a16d8398806f9.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"So what now?","uri":"b62e811220e5e1f98345166e57e25b08.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Sounds great, thanks!","uri":"15dcb9bd6067c787e765a9fef534a8eb.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Thank you.","uri":"1653c79c23e827721567a7a359de722f.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Thanks, Isadora.","uri":"9213a88c93a116424ac4dbf0f08547b6.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"There we go! I's say that's the totem finished!","uri":"1e680a1d72811851d3ed7712b6c093ea.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"Well, I guess you can consult with Isadora on how to carve the totem. While you do that, I'll get to work on rebuilding the pole.","uri":"1b9708288040d0fd3659bbe6f8db1b05.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Female","text":"What's next?","uri":"3a493fba465b8b79922ad6a55dd9944a.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Ah, sorry to have disturbed you then.","uri":"6c11bd7b66c00281ed519ab487933a3a.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Any specific type?","uri":"d4679886bbdcf2c84409898984177f59.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Cycle?","uri":"5f1220c668a5dd437671f7b02c01ddfe.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Does something have you preoccupied?","uri":"ef4f3dfa55cae44f52063e579b888aeb.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Have you asked around?","uri":"b9a56ddbec9ba3be501ed8d20ce0e972.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Hello again. If you don't mind me saying, you seem quite preoccupied.","uri":"557773a7687605d4932540a801acc83a.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Hello.","uri":"ede3fbca98ea2533821b1cc25d109b50.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Hmm... Well, why don't we take a closer look at this totem?","uri":"05e68dcb2983420321c791ba2d35c05c.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"I supposed that makes sense. I'll give it a go.","uri":"37801f5fbb1e2c3aeec0d34b6d4a07f7.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"I'm not sure 'we' is the right word...","uri":"7ffab19b947cb95a956d31cf4e9aa58d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"I'm still working on it.","uri":"894bbc4f8f691df7daaa087040a24c67.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Interesting... It's like some sort of ritual.","uri":"59eef0a1debae045989d934a02f78d49.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"It's a beautiful totem.","uri":"fd9d703dacad6e94ab336e611ed9144d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Meaning?","uri":"8db256653c7f6bad8d66def62fc7f7af.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Okay then. So wooden items? You mean things like bows and shields?","uri":"c02128782398ea3555e11ecc2bd0fa19.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Okay, I'll be back once I've done that.","uri":"23cd89944cb3270d11db0e0584fb49fb.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Or survive interference from... you know... us.","uri":"937516cfb546c071ccf4dae3f5c6003b.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"So we need to fix the totem. How?","uri":"7fac77093db97010d677651d3bb86ab9.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"So what now?","uri":"0298f271930cac3d12d54e87e6bb9bf1.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Sounds great, thanks!","uri":"8e278d65f871c4ee320b12c50974d9e3.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Thank you.","uri":"0640e75d1f9aedd5a599ca03b9a23200.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Thanks, Isadora.","uri":"e031781dbab5fdec0d5e3f070d1ecee4.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"There we go! I's say that's the totem finished!","uri":"3e668eaa47829ceaa1f55685d76b34aa.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"Well, I guess you can consult with Isadora on how to carve the totem. While you do that, I'll get to work on rebuilding the pole.","uri":"db4328c1948cd55ec6787cae6efdbe3b.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Player Male","text":"What's next?","uri":"86ca91b2d2b45711800335518e1d02ab.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Any luck getting that totem rebuilt?","uri":"9f37352151688d5e625dc50ff3490b83.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"As for me, I'm going to keep studying them. I've learnt so much today, both from Isadora and from the ents themselves. I've already documented it all, but I'm sure there's more to discover!","uri":"7120562c123f981821911a71e8190c8c.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Be sure to check in once in a while to compare findings. I'll happily trade items I find around the valley in exchange for your research assistance!","uri":"6933dd42a7ff2569ee95ee37ea26d076.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Did you see what that ent did?","uri":"755ba500506db0f92628868c866cce99.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Don't forget, you'll need to make carvings of the animal spirits that are currently in this area.","uri":"973a9eaf4f812083009acfdec37746b9.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Exactly! These totems are dotted all around here. They seem to be very important to the ents, but I don't know why.","uri":"6e8f45dad77af86bf48de6df7dfadc2f.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Exactly! Try decorating the totem with those kinds of items. I reckon four should do. Oh, and be sure to use the same wood you used for the totem itself.","uri":"2f36d0326380ebc354b28b02f9f80b6f.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Good idea. If nothing else, it will be useful to document the carvings on it. Come, let's have a look...","uri":"728d9aafd574a1d4a0e9b1cdc1fdcda6.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Hmm... I think the child's assessment is correct. The ents probably won't be happy about what we've done.","uri":"12f8c76fb196eabfcf61d4ada35a83b2.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Hmm... The pole is only going to be the beginning though. We're going to need to carve it... I really should have made more notes on the carvings...","uri":"4edc8d7e2ee16cf83694ee503efe021b.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"How's the decorating of that totem going?","uri":"bb3b3c183c970c86daa7c1af220f014d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"I couldn't have imagined a better outcome! Not only have the ents accepted our new totem, but they've also left something behind!","uri":"ef70242d7336ae973cd0c093e8ea0921.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"I reckon you'll just need one set of logs. Oak logs should be enough, but I do wonder if using better wood would help it survive the elements better...","uri":"1bb2b6db0721716a197087bf89e0a234.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Indeed! Look at this bit!","uri":"1268e3dedd7d7c3b6f25113c6e668e4c.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"It looks like it was made from oak, so presumably oak logs should be enough. However, I do wonder if using better wood would help it survive the elements better...","uri":"0a349d464fca740949a000cd94d05695.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"It seems the ents are very appreciative of those who maintain their totems. Given you seem to have a knack for it, you might want to keep helping them. They have plenty of other totem sites in the valley.","uri":"53ca4bcc846a38f8d745ee3d535f3a4f.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Let's see... First, we'll need some lumber to rebuild the pole. I reckon one set of logs will do it.","uri":"4d524dc2ba5d27a5528311e162662dbe.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Look at that! I think it looks even better than it did before!","uri":"18d192cb5d51b419ceaead5fa80a45b4.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Not a problem.","uri":"e1653e0261b9d41300ada8ef38af62f0.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Now, the finishing touches. Apparently, the ents appreciate it when wooden items are returned to the forest.","uri":"8c1a90c70a19b5cddeda407349c67a13.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Oh, sorry! I was lost in thought. You gave me quite the start!","uri":"02205bd2a4dfd85291819c545a6c7037.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Oh... There's a child.","uri":"4eb31ff77ff6e9e7c735f891f86f4d76.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Remember, you need to make carvings of the animal spirits that are currently in this area.","uri":"a237907eabd622e5280c1fe8ba2922c1.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Speaking of which, here, take a notebook for yourself. I've left a copy of my notes in it, but you can also use it to document your own findings.","uri":"c43f6a8ac62158eb94e294596bc34717.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"That's a good start.","uri":"c8c57e376761c11d78fa6ecb4293386b.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"The cycle of life, death and decay, I suppose.","uri":"7f4862ecd50e2af4f0cc52db83931600.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"The right ones being the animals that are currently in this area.","uri":"716bc6c1b0bddcf5506b4e7d20da9896.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Until next time, friend.","uri":"7d62568a229b94ed490dddc99779ebb8.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Well, actually my name is Ranulph, not funny man...","uri":"8999444906c7a8862d7a8eaaf4c205f9.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Well, this is definitely the most 'dialogue' I've had with the ents. Isadora here has been a great help as well!","uri":"6a7b6005436775cb24e6797543a4f715.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"What Isadora said basically. I reckon four should do. Oh, and be sure to use the same wood you used for the totem itself.","uri":"5550d0b2e6581749e92e279138341e29.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Yes, according to Isadora, the carvings that were on the totem represented the animal spirits around it. However, the animals were disturbed when the totem fell. Some left, but new ones arrived.","uri":"d8fd4c90a6e50545aad86447bc898681.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Yes, but the locals didn't really give me much to go on. All they told me is that the ents, totems and spirits are all part of the natural cycle here in the valley.","uri":"fe56b4d768c1b7b8d8ad78c1b23ec6cc.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"Yes! It's these ents you see! I'd never seen anything like them until I came here. Look, here comes one now...","uri":"f280e749f135b3d8a9b479bad89df09d.mp3"}
+{"quest":"Vale Totems (miniquest)","character":"Ranulph","text":"You've quite the hand at carving, my friend.","uri":"74b87307eb17b512d83b958014c4d859.mp3"}


### PR DESCRIPTION
Dialog row shard (`db/rows/vale-totems-miniquest.jsonl`) for **Vale Totems**. Its audio was already on `sounds`, so this writes the DB rows that were missing. The database branch workflow rebuilds quest_voiceover_v2.db from all shards on merge.