### PR TITLE
feat(db): Eadgar's Ruse dialog rows

### DIFF
--- a/db/rows/eadgar-s-ruse.jsonl
+++ b/db/rows/eadgar-s-ruse.jsonl
@@ -1,0 +1,254 @@
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Ah, dat look like nice tasty human.","uri":"3009b4458ead69f92854ff70831e5ff5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Bring back a tasty human for Burntmeat's stew. If you find tasty human, Burntmeat will give you good reward.","uri":"028db391fae50ffcc7531e387dc73251.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"But Burntmeat also has quest for human!","uri":"3801036d3f367b93e2ff2553f34f8456.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Bwahahaha! Burntmeat not give his greatest cooking secret away so easily.","uri":"28fd476f1e338f44d5b3ef8311698433.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Bye, bye.","uri":"f8679cdc860788cbc052422d86227f74.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Did you find tasty human?","uri":"c693532eadfd242e2d8f5681fe79cde5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Did you find tasty human? Burntmeat smell something good.","uri":"a4450a5f62429db897ff4359c4a07a17.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Hah! Trolls pick it all until none left, many years ago. Only remaining stock in storeroom.","uri":"c656b1d94d80d379b87811ebe0f26226.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Hmm? What human do in troll kitchen? Burntmeat tired of cooking goats. Human look tasty.","uri":"532aff8c28cd27ede5ac66f6197cb9ca.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Hmm. Burntmeat think you probably right. What human doing here?","uri":"14cc8177a9cf370fac335100b8d4e69b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"It first thing I ever try to cook! Very precious to Burntmeat.","uri":"d6bd644d929691fe1f5517b6258ba50f.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"It well guarded, and Burntmeat hide key in fake bottom of kitchen drawer. Nobody find it there.","uri":"a0e3670bc530a7047c0721f6e37ac299.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Slurp, mmm... Human stew cheer Burntmeat up!","uri":"4cea2d5446067e7bf8c71bf0750bb7c8.mp3"}
+{"quest":"Eadgar's Ruse","character":"Burntmeat","text":"Yep, sound like human too. Burntmeat put it in stew. Good work, human. Burntmeat give precious reward.","uri":"6e1dc7c50273ba2d8cdb5696cc1c6bdb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Aha! I have a plan!","uri":"f3a02604f4e647095b5f9f816d7277a8.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Although the trolls might get suspicious if it doesn't say what they expect a human to say...","uri":"b99ac2c47601c6b1aca62ea3e555fb69.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Anything else I can do for you?","uri":"7c0c3bd6e2a77d0c4324b410fcaf6347.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"At the zoo, where else?","uri":"736f08aa57a049242d76b55561127bcc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Excellent, thank you. Now just go fetch that poor parrot back, it's probably had enough by now.","uri":"d8170646b16c0b4ed9b97cefacf8c3dc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Glad to hear it!","uri":"6db7b6bea2e5d935af474d82629ddec1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Go on then, give it to the cook!","uri":"b1bd0af3b4966bf71042eaf681fad5c2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Good work. How about those other items?","uri":"dfa32669435ace5b899decb4a615b3ba.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Good, good, everything is almost finished.","uri":"7002c6419adb9b9ea42d174b761ec02f.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Goutweed is used as an ingredient in troll cooking. You should ask one of their cooks.","uri":"e9954233db904bd2276e4266cb148907.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Hand it here...there we go! Can you tell this isn't a bona fide human being? I sure can't!","uri":"1b413933ef6487e5d7c73c8b7cb6a2a5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Have you given the fake man to the troll cook yet?","uri":"e3aaed35bc434dc8300308d2c602da3b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Here you go! Enjoy!","uri":"c0fd92f5763deb248e7aa9762762bb08.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"How are you getting on?","uri":"8ae098f7f29b560eac7732252a676cd8.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"I happen to know that the trolls are susceptible to a certain kind of plant that grows around this mountain. I call it Troll Thistle. If properly prepared, it can be made into a sort of Troll truth potion.","uri":"d7f81c1507625523ecede086f3c1a5b3.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"I told you, put it somewhere it'll learn to say the sort of thing the trolls will expect it to say.","uri":"742d3353229ef0077daa920dd49e73fb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"I'm a man of few clothes myself, so you might want to ask old Sanfew about that one.","uri":"be5f3ba51facdf4b2d7c0bb99838d7be.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"In any case, this is my home, and I'm not leaving it. And this area has the tastiest goats!","uri":"29913970ceb0806603b982049f034e74.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"It's in Ardougne, south west of here.","uri":"6a6922991d20bdbabbd0a603e7a3a419.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Just give me a moment...there we go! Can you tell this isn't a bona fide human being? I sure can't!","uri":"18f37ce38849c3da3a5470749286703b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Never mind, here's one I prepared earlier.","uri":"2bb61959d3dbf0ad7dc35a0fb9e1786e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"No, of course not. We need to make sure he'll tell you what you need to know.","uri":"079e695f8b6d5d79d7c25c07560d1ecb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Of course, we can't just give him the dummy and expect to get anything useful out of him.","uri":"7d61c8283a8ce3922694b47f856f3a77.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Oh dear, that's no good. You can't just go hand over a human to those trolls...","uri":"56c8b0cb3edfb305a8beca0d4582e7d5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Oh, it's you. Have you got me a parrot yet?","uri":"102791e592e54266f1be1b6f83dca162.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Oh, it's you. Have you talked to the troll cook yet?","uri":"f886ae82714078f62c525d45fccb42ad.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Oh, it's you. You didn't lose your parrot did you? One flew over here and I managed to capture it.","uri":"fe55e83896bdfc699fba3fcea4188e1b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Sanfew, you say? Ah, haven't seen him in a while...","uri":"7c41e63a2393ba34ffc7ca5a7f2948dc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"That's easy, we'll just stuff it with a few chickens. Everything tastes like chicken! Five raw chickens should be enough.","uri":"b8240165198f0e873944b31cc8ce328d.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"That's everything!","uri":"ecd73286ebc9afe9fb9b9e95d1f34d91.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"That's the plan. Anything else I can do for you?","uri":"9d98544379ddfdd25bba6389e6319c15.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"That's what I thought.","uri":"81c63850f0fa975067c8a2a67c93391f.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"That's what the parrot's for, of course.","uri":"4a448425dcc31326459450c32af0185e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"The chef's recommendation for today is mountain goat stew. I'll give some stew in exchange for logs for my fire. They're hard to come by around here.","uri":"02eb60909aa70a01015bd7b6e23e4c60.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"This is likely to be screaming. There's bound to be a good spot somewhere in the troll prison.","uri":"416d6eb69ad79ce958f919a528b30462.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Troll Thistle grows around this mountain. If properly prepared, it can be made into a sort of Troll truth potion.","uri":"c932a60e1dd2576437df47c9cd824ecc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"We'll just make a scarecrow. We'll need logs, and 10 sheaves of wheat for stuffing.","uri":"a7017f41f5c735260055c9e8ddc5a2df.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Welcome to Mad Eadgar's! Happiness in a bowl!","uri":"83fb8341fb978eab8286562aab347383.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Welcome to Mad Eadgar's! Serving all day, every day!","uri":"b6b642ddb699a460b12925e679c1c35e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Well, go see if the zoo have one.","uri":"4109728cd2998a55560326e4722b7331.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Well, I suppose I do keep getting captured by the trolls and thrown in prison...But they always release me in the end, I'm far too old and skinny for their tastes.","uri":"e2acfabbed4abaeccaaa91093cd60bd0.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Well, we'll need to dress it up anyway; if we use dirty clothes it'll smell human to the trolls.","uri":"511a672eced6fb9fdfc5cd6761f37b94.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Well? Did the plan work?","uri":"8cff39a9118142a75da566953690ba57.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"What we need is something that looks like a human, sounds like a human, smells like a human and tastes like a human.","uri":"8b9cdbff94fd52cdf5f137e4d0a31c3e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Would you care to sample our delicious home cooking?","uri":"54de6447723b218241a7de43ba3f79d5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Yes, yes, of course. It's quite ingenious really!","uri":"e2cfd41c2f47574ac0edc8cdeb660e87.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Yes! It's bound to work. First of all, I will need a parrot!","uri":"83a1b71c7db0c5f17f3919a1bdd93bdf.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"You bumbling imbecile!","uri":"a245ad44d05f4a86033edd883e83d9a5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"You now need logs, of grain and dirty clothes.","uri":"85383dbf2d62b593e25dcd804e3b5f52.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"You should hide it for a while somewhere it can pick up some more appropriate catchphrases.","uri":"210ea7a3bdc868058550b2fe59a76b60.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"You'll have to dry it in a fire, then grind it and mix it into a potion with Ranarr weed.","uri":"bad676d50bd54d31505bbc04447de453.mp3"}
+{"quest":"Eadgar's Ruse","character":"Eadgar","text":"Your loss!","uri":"8e44ea9eb4133b738738602aa1fe73f9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Fake man","text":"Aaaargh! Somebody save me!","uri":"b250cba7d133e2a8f1742e2f75e7bda6.mp3"}
+{"quest":"Eadgar's Ruse","character":"Fake man","text":"Heeeeeeelp!","uri":"23965f9e14a9bcaec02e86a1e20ae685.mp3"}
+{"quest":"Eadgar's Ruse","character":"Fake man","text":"What am I doing here? Ow! Where's the rest of the Guard? Agh! I won't tell you anything!","uri":"74a98b2ede1138d42ae8b46a44696406.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parrot","text":"Ah, hello Sir. Could you please free me? I seem to have... OW! What are you doing? That's my spleen!","uri":"dfa16de5cfea66ce79dc4488b65d337b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parrot","text":"Pieces of eight! Pieces of eight!","uri":"683fcf7e9ec5fb23316500e000547104.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parrot","text":"Polly wanna cracker!","uri":"61ad46f3cb8d8341b3924781d638045b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parrot","text":"Raaawk! Polly wanna cracker!","uri":"dc436d28cff114e938c82f164550bb83.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parrot","text":"Sqwaawk...*hic*","uri":"7ef554293d68d8e242c67d81ff51a60f.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parrot","text":"Who's a pretty boy then?","uri":"69f11b9f9f2d36eb59e575deeb16f12a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"Good day, good day. Come to admire the new parrot aviary have we?","uri":"995f25dd05b3f79ec522cc05fbeb8da7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"Hey! What are you doing with that parrot?","uri":"d7ab651f4c37e7b4feca64448136ad01.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"Isn't it just?","uri":"b38a712ba314e9ef6bcc4e9b0eff2dc9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"It looks drunk! You should NEVER feed alcohol to a parrot!","uri":"596008a334fc050d5d0ce791e41e2695.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"Just recently. It would have been sooner, but some wretch thought it would be amusing to replace their drinking water with vodka. The vet had to nurse them back to health for weeks!","uri":"3919be0523a648e5c8e6d5cf5ddd099a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"Oh, thank you! We're ever so busy here at the Zoo.","uri":"b660bc38ae26d8cc92dc98c46a2c0e77.mp3"}
+{"quest":"Eadgar's Ruse","character":"Parroty Pete","text":"Well, fruit and grain mostly. I try to give them a balanced diet, but their favourite treat is pineapple chunks.","uri":"36d155054ff6d2584756591c2b5f3dd7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"A PARROT? Where am I going to find one of those?","uri":"b3efd2973e3c0094d5156df180fed95e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Actually, I don't need to speak to you.","uri":"c003a8d94f8bf2f763565dbc8510e785.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"And how are we going to make it taste like a human?","uri":"42aa2fb4bb21216b8ce3b336f24ddaf7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"And how do we do that?","uri":"191f63b443211b52844c69dc35421f20.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"And what exactly do you want me to do?","uri":"1e3adbaea99ec01d35232e2a8bc13255.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Eadgar says he needs some dirty clothes for his plan, and he said you might be able to help.","uri":"aa5385fc2e38b01aa803aacad0b193fb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Er, hi.","uri":"d53b8f41693e5eddfdbecf00275e2df1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Erm, not yet, but I'm working on it...","uri":"71128331ff3c6fe5d2b5c8662ecbd519.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Fine.","uri":"f58147a818e397e602cafd04cbb1d7e5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Hah! Got you now!","uri":"131ee0aca065d7b919c18a58e8d4e4f9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Have you any more work for me to help reclaim the stone circle?","uri":"fda82a77414a7825ca99b8428a74a360.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Have you any more work for me, to help reclaim the circle?","uri":"29d73ec9b1f31e9ca86f4eb2e1b6a476.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Here it is! Now are you going to explain your plan?","uri":"26e813ba0b730a955250831a93af22e9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Hi!","uri":"d7a42326932fce233bae3fe66d5fc148.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"How are we going to make it look like a human?","uri":"4d791f17f69720d7ca91c06a0d5f90fc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"How are we going to make it smell like a human?","uri":"ea6c08542241ea2f20cbcc19707a3545.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"How are we going to make it sound like a human?","uri":"9507aec2d3ef676b35625894c94c18a9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"How do I make the troll truth potion again?","uri":"7615c7e60512bcff11d0317be0bb2c53.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"How do you prepare it?","uri":"623a5d41791fa815e771f8ed2f5fd930.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"How's the stew?","uri":"cdc81902b74d22e381f7ad05540c51ef.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I don't think it's done yet.","uri":"5c6322d6203959fbc3b823a0f7fa981d.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I have logs, of grain and dirty clothes.","uri":"bd3dfc4f907ee25245a27d05ae2962f5.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I have some goutweed!","uri":"51e1bcb4514c2ef99f5a5820310eff83.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I have some more goutweed for you.","uri":"a287bb20ef737ee56572bf20fb973075.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I haven't been able to find one yet.","uri":"d3da9aef511e2c912fd4ea8fc0dc98a2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I hid the parrot under the rack in the troll prison.","uri":"8aa6bdb59ff021bf75775de33ddc3ea2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I need some way to slow it down...","uri":"eb1e91ded368560b4662a9559ad78c09.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I need to find some goutweed. Sanfew said you might be able to help.","uri":"727ec0f85718b5dd52f76ba52a3ecb03.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I talked to the troll cook but he wouldn't tell me anything, and now he wants me to find him some tasty human for his stew.","uri":"45d08751f204a7770df75ec179513ea2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I think it's probably heard enough.","uri":"47a2a8c905581670f177baabafb13d3b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'd better not mess around with Eadgar's stew!","uri":"bba8b384f0b17d61d0fcc6161e5ee129.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'd like some mountain goat stew, please.","uri":"277eb921eab5561ca517218952065c4d.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'll be going now.","uri":"686bbd1c09153a5ea45326ae2482e751.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'll do it.","uri":"084350d0860bc6c860a7d1b46c8346c1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'll get on with it.","uri":"e6413dae416f373438d3e91792876a56.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'm on a quest to find some goutweed.","uri":"ed920fe4e8700bac38b5831d06da422c.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I'm sure Sanfew won't be happy when I tell him it's your fault he can't perform the purification ritual.","uri":"96dfcac45d3c1b003e52b53f89091e17.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I've brought the parrot.","uri":"b35c57e8b477b66df3148a4c587ec58b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"I've got the troll truth potion.","uri":"49410fff7f634757389179fe7fc5822c.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"It's a long story.","uri":"f95d399244fe003ee6877501aaf18291.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"It's very nice.","uri":"1e86d9e6fd07b097a2c4eb6705927ab2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Nice day for it.","uri":"214cf74acbb625c0e2b6444adffa4791.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"No thanks, Eadgar.","uri":"55c2d7770c901ff8fe0ddb247ca3cf58.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"No thanks.","uri":"9479fefe62d8f0e882e0b9f0577c5698.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"No. I lost it.","uri":"dd131bcccaef677aad0025d97d6069fe.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Not yet.","uri":"44e50e3fe0c79197c2dde343a304a9b4.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Nothing.","uri":"b19b0a4f139212f38ab2bea45cc6c703.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Of course I would. They're just trees.","uri":"123262f2afb0e8489058b24c8e66a261.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Oh, you don't want to eat me! I'm a tough, hardened adventurer, not tender or tasty at all!","uri":"7bd1706fcd99990178908eb5684d4aa9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Oh?","uri":"d0f20af565f3f21c91f76c684bd71adb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Okay, I'll be back with that soon.","uri":"e0d6126b88340986262b50fd8d2e7745.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Okay, I'll be right back.","uri":"47903666031d1b1700a373713b4f4e82.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Really?","uri":"7b10bbae8ead50ab26423ca02bda98ec.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Really? What is it?","uri":"c8bb43f3ca5c1205742ae55ca9b9603e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Right. I'll just...go fetch that for you then. Bye!","uri":"9367648682c5223708b8c90ce19f2e0b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"So, where can I get some goutweed?","uri":"e5040368ad9ef2fa4de311653dfb4b2b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"So, you're doing laundry, eh?","uri":"64f2247a7fc4f81bd8f8bd34a09a1f29.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Thank you... and how's the stew?","uri":"a3134812a776706ad6354f74443c9ece.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"That's some well-guarded secret alright. I'll just be off on my way now.","uri":"f03c308748e370b6a9f593453463cc95.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"The parrott flew off, I wonder where it went? Silly thing prefered Eadgar to me!","uri":"996f07e51bbc59bee05f2f3dfaedbc79.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"They won't drink it straight from the bottle...","uri":"e23cfc9096646f7004585e0f7cbc36b9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"This is burnt meat.","uri":"88b54bb28b15eb6ff8315e66a02057bc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Well, good thing I found it! I'll just take it to the vet for you, shall I?","uri":"c861a803afde4f33fdf7de476b68f477.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"What do you feed them?","uri":"53c0047aee0ee247ca7d731f263ba39c.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"What do you have to offer?","uri":"e4bfe4649960a34abed79d25f2aa4bdc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"What should I do with this parrot?","uri":"edd8855a76c884a9b7971a0a16227abf.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"What was I meant to be doing again?","uri":"69388219484214268395a66aa32f6dce.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"When did you add it?","uri":"e7ea24e6dcb085aab826e0431fee3fee.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Where's the zoo?","uri":"4d83f349ca4c69b3ed7a47ea7b687972.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Why do you live so close to the trolls? Isn't it dangerous?","uri":"2f531bc1763ba78e10a6a914e7fc54c6.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Yes! I can get into the storeroom now.","uri":"18ad9e6deb0be0b373481615f91491c2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"Yes! Look!","uri":"32cad59a6f790abf78dcd98d35944091.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"You wouldn't be able to spare any of those dirty robes by any chance? It's a matter of the utmost importance.","uri":"139cb346ad14ef6f96f5440825aa265e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Female","text":"You'll give me those robes right now...or I'm going to cut down trees until you do.","uri":"7bf68b805e3e2c01f136b1170cd5df9a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"A PARROT? Where am I going to find one of those?","uri":"c6ddc2c798fcaff5e43ab28825565682.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Actually, I don't need to speak to you.","uri":"3edfee4c3c84a0b4bf995860e6b96c2a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"And how are we going to make it taste like a human?","uri":"d4768a0513f858eeafacfd4338b98272.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"And how do we do that?","uri":"2c7659d70e744844c1e0a601874591fd.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"And what exactly do you want me to do?","uri":"6c0484b56107c541f2b1c4562c3203d8.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Eadgar says he needs some dirty clothes for his plan, and he said you might be able to help.","uri":"ea4e680d3840c1ed578f70c2cc17b801.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Er, hi.","uri":"ed767d0dd1e5145f685df03e7efd4a2a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Erm, not yet, but I'm working on it...","uri":"e3b42a773be1e9a3ce7b5e64626b7e71.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Fine.","uri":"a49c6af957e849d20eb126431359bcd0.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Hah! Got you now!","uri":"037c8c86ad506d93cdc7bed15a6a1415.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Have you any more work for me to help reclaim the stone circle?","uri":"c198b2058b9e72a2ab8de30a60da02b0.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Have you any more work for me, to help reclaim the circle?","uri":"cd0a7836b42fd91daa65d271a776c822.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Here it is! Now are you going to explain your plan?","uri":"bcfd587629445dc0dd909644fc336734.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Hi!","uri":"88073ee92cc1657aa28ce53152c6112b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"How are we going to make it look like a human?","uri":"f2ad60675c8d1ae221cfbc0687133187.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"How are we going to make it smell like a human?","uri":"e9d865c93d52d5c4516c53afb677c478.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"How are we going to make it sound like a human?","uri":"df14503afc0d909d5a3e085637bf7d01.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"How do I make the troll truth potion again?","uri":"3af27a89a6651e4b4054733a6f8ba79b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"How do you prepare it?","uri":"b03fcb3e580e9e6ae5fef0ba66813703.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"How's the stew?","uri":"5f87b3a37a45049f16df19dba4a1f245.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I don't think it's done yet.","uri":"d5328a6cf1c9ef91ce4b22819ea1db11.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I have logs, of grain and dirty clothes.","uri":"e73495140f1bade75acd2e2ffb83acb7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I have some goutweed!","uri":"f4b8dc65a65e0f7c435ce20e82fad6ea.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I have some more goutweed for you.","uri":"f1271e0a9fbb691e40559e4101394b2e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I haven't been able to find one yet.","uri":"54f27aa63b3fedc31f4dcf873a61beed.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I hid the parrot under the rack in the troll prison.","uri":"b32abc57305aecfdc2fdf52991d5e41b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I need some way to slow it down...","uri":"13452cf241a1eeab52627ba94da24758.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I need to find some goutweed. Sanfew said you might be able to help.","uri":"87aa6ae5a935acb17ae8d409686d2e97.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I talked to the troll cook but he wouldn't tell me anything, and now he wants me to find him some tasty human for his stew.","uri":"c4c32436ca12e6d0bbc012d1602d1408.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I think it's probably heard enough.","uri":"8c20e73f062475b94bce60b77f86308a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'd better not mess around with Eadgar's stew!","uri":"a6f40123e69c4bb148bf20c2efb16488.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'd like some mountain goat stew, please.","uri":"0c091726880f84baf784da3b1725d2cd.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'll be going now.","uri":"63556b2db96d46dcdd8cea0412097c27.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'll do it.","uri":"5497531304e09913cf1ef4d4e7be1c04.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'll get on with it.","uri":"39d2396327753bd74a5f9a8e2abba329.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'm on a quest to find some goutweed.","uri":"ec5dbea7fe75193b5fadd5c8ba655217.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I'm sure Sanfew won't be happy when I tell him it's your fault he can't perform the purification ritual.","uri":"0b5c7bdab0cc914dfc6db7b77bc9764a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I've brought the parrot.","uri":"8a9841b5c6b3335980e36e7e7d4f03ba.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"I've got the troll truth potion.","uri":"6476f47f010bbb97f903cbb41a85bd5b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"It's a long story.","uri":"05f4e321a44dc04e7dcd3a0824b0fa15.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"It's very nice.","uri":"129ce540e7ba462f4369f6b9b6127531.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Nice day for it.","uri":"b1195dd6863ae6195e5d06177e9693e2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"No thanks, Eadgar.","uri":"e37ff3fa945e30ff39f4b7e7f17c95aa.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"No thanks.","uri":"ee9a9c1177e434d251d60929b380ad81.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"No. I lost it.","uri":"27d273397f789ac814bf4d91b3a4765f.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Not yet.","uri":"66688303bc04a5362935a9651ad8bcc1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Nothing.","uri":"37a43433544f46c57f99383790cfa1e7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Of course I would. They're just trees.","uri":"f6461c4bccb7f5e73782de9a87b28ef2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Oh, you don't want to eat me! I'm a tough, hardened adventurer, not tender or tasty at all!","uri":"2b277dcf48ce9c2188086f603df952eb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Oh?","uri":"e3a36ff1230564fa40e5b15e7ac8720d.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Okay, I'll be back with that soon.","uri":"c9971316ed0198d9d810ff61e76797aa.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Okay, I'll be right back.","uri":"5fb4b335eb6e9243fcce4d3733b6a43b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Really?","uri":"448b0ceacba21cd37d88f3ffc399b3e8.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Really? What is it?","uri":"f5aa92c7efdc2528726bcade2b711ba9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Right. I'll just...go fetch that for you then. Bye!","uri":"7e9ed4a6f68728f341ac630d4a6143e4.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"So, where can I get some goutweed?","uri":"21d2ff1ad18d73c6af46019b0a0143c4.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"So, you're doing laundry, eh?","uri":"02c601edabcf0d7a7be058e9fff191a1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Thank you... and how's the stew?","uri":"0f432e29225399f298276a50385014d7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"That's some well-guarded secret alright. I'll just be off on my way now.","uri":"3e9f7f85c27821d6cf332a8829aab8c7.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"The parrott flew off, I wonder where it went? Silly thing prefered Eadgar to me!","uri":"eb284b29d26c5877139f1238ed130bd9.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"They won't drink it straight from the bottle...","uri":"1d249dd764b23390bf52ce3d09175585.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"This is burnt meat.","uri":"2a3d6a1c6e59125aa3aca1252395c063.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Well, good thing I found it! I'll just take it to the vet for you, shall I?","uri":"c0ae16d14cfaf34e721c880d544b34cf.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"What do you feed them?","uri":"954ad63c633f0c662eba09f98cc72eef.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"What do you have to offer?","uri":"18ed0a3c0f6727120159dcf383367f9a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"What should I do with this parrot?","uri":"1a4d1a4c98b071cdc10a23f7653c3a69.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"What was I meant to be doing again?","uri":"ed9bca808094abd1cac0e3958d2881d1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"When did you add it?","uri":"e786f23c1ee1e17077c28f982519be19.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Where's the zoo?","uri":"4e020d00b39af5e54ca78a1ea7da7efd.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Why do you live so close to the trolls? Isn't it dangerous?","uri":"be864f377541b6324c5cd5bf1a03c38e.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Yes! I can get into the storeroom now.","uri":"e365b7f64d3fb9fff242acdc8aa32bb4.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"Yes! Look!","uri":"a72e926ce8e9608395a0d392aac3c2df.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"You wouldn't be able to spare any of those dirty robes by any chance? It's a matter of the utmost importance.","uri":"7ea00f7ff90af07f08402cb5ce533022.mp3"}
+{"quest":"Eadgar's Ruse","character":"Player Male","text":"You'll give me those robes right now...or I'm going to cut down trees until you do.","uri":"9906b2eb34781719752d065028f5a1e0.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"'m afraid you are not yet learned enough in the art of Herblore to be able to help me, adventurer...","uri":"b892b4b490811a03e7ffb0b9244e5ec4.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Ah, good. Here are some herbs in exchange.","uri":"6aa33c3511f2d1a14a1432a9a67e6b44.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Ah, you've come just in time. I need a certain herb for the next part of the purification ritual...","uri":"7c9ee91b64e40505c443dc2c9c213619.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Excellent! I will be able to complete the next part of the ritual now. I will teach you a new spell and give you some of my knowledge in Herblore as a token of thanks.","uri":"529b1e076b5ebe9ecd56517219311e0d.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"I've told you already.","uri":"dad487d94e442f72f841c9b034c19b24.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"If you ever come across more goutweed, bring it to me; I don't need any more for the ritual, but it's still quite difficult for me to get. I'll exchange it for some other herbs.","uri":"26704101fa9abe5bea936cbf8429758a.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"It used to be quite common, but nowadays only the trolls know where to find it. They use it in their cooking, you see. It's a very prized ingredient.","uri":"2eb7b8f961af7c9720a3b40400945feb.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Journey to the north into the land of the trolls, and find the secret of the herb the trolls call 'goutweed'.","uri":"a5cb138db6c770b79e56099b3dd5cb59.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Journey to the north into the land of the trolls, and find the secret of the herb the trolls call goutweed.","uri":"bdce479d66ef63deb426e0a26fba7ff8.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"My friend Eadgar lives in the area, and he may be able to help you. Bring some goutweed back and I will teach you something useful.","uri":"f62c6d2d915166d1e8a88995687cd387.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Never mind then... I think Tegid is doing his laundry outside. You could ask him if you can borrow one of his dirty robes.","uri":"87d342dfd965f7e5d661e30edcb1385f.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Not just yet, young 'un.","uri":"4fc69ccf9518ff8affe7eb0bac3413dc.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Now why would he need that?","uri":"88b29e39838edd56264d08c94c10942d.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Oh well. No doubt some other adventurer will eventually come who can help me.","uri":"dd52912ec9917a5af14aa951110c6e51.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Thank you, adventurer!","uri":"9c2e8d3a2506908d2cc723d7c2034b4b.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Well, not right now I don't think young 'un. In fact, I need to make some more preparations myself for the ritual. Rest assured, if I need any more help I will ask you again.","uri":"f32c231e691a4b0d03cd27d47a27a8bf.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"Well, we all make mistakes sometimes.","uri":"ee8cf8622a5c4faa4bf8361de8b30973.mp3"}
+{"quest":"Eadgar's Ruse","character":"Sanfew","text":"What can I do for you young 'un?","uri":"cf3c2cf94ea5fa269ccb6a9afa0f4f56.mp3"}
+{"quest":"Eadgar's Ruse","character":"Tegid","text":"I suppose it is.","uri":"d10450fb59b45dda669bc1a02e1692d1.mp3"}
+{"quest":"Eadgar's Ruse","character":"Tegid","text":"What? No! These are my robes!","uri":"7b8d29c530cf04be21fcd40684bc8948.mp3"}
+{"quest":"Eadgar's Ruse","character":"Tegid","text":"What? Oh well, if it's a matter of that much importance, I suppose you can borrow one...","uri":"3e4a99c70ee62d1bdb2844b2e43a0445.mp3"}
+{"quest":"Eadgar's Ruse","character":"Tegid","text":"Yes. What is it to you?","uri":"36e8c8dffdf1577e3da4c490506fbca2.mp3"}
+{"quest":"Eadgar's Ruse","character":"Tegid","text":"You monster! Take the robes and leave this place!","uri":"53b05d725bce6c6b26d23450cc456ef0.mp3"}
+{"quest":"Eadgar's Ruse","character":"Tegid","text":"You wouldn't dare!","uri":"6bb0f72d05f5d3e6c857333a61db9526.mp3"}


### PR DESCRIPTION
Dialog row shard for **Eadgar's Ruse**. The database branch's workflow rebuilds quest_voiceover_v2.db from all shards on merge.