### PR TITLE
feat(db): Mourning's End Part I dialog rows

### DIFF
--- a/db/rows/mourning-s-end-part-i.jsonl
+++ b/db/rows/mourning-s-end-part-i.jsonl
@@ -1,0 +1,442 @@
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Ah, a disguise. Good thinking.","uri":"dac57b3be78fd1fe4fff9f41e5879190.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Ah, a disguise. Good thinking. Use it to enter the Mourner Headquarters in West Ardougne. Once your in, see if you can find out what they are doing in the city.","uri":"e2d36e0a7ec5f0762f691a9b07c82f58.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Ah, glad to see you made it. Welcome to Lletya, home to the Elven Resistance.","uri":"b6979bd4a06536ab34e1baa89c49af07.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"First of all, we need to know how close the Iorwerth elves are to finding it. Do you think you are ready for this?","uri":"8911391ae9dca82f50b63affbc682f2c.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"From what we can tell, it seems that Lord Iorwerth has promised to support King Lathas in reclaiming some land his family once owned.","uri":"242620bb0fdc9a8258e346c21f2113b1.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Great work! Stick with it.","uri":"61244d37673c106ca86d8526f0005201.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Hmm... Well you can try asking our local seamstress, Oronwen, about the trousers. As for the top, you'll need to find a way to get it cleaned. Maybe you can find someone who does a lot of laundry. Someone who wears lots of white might be a good bet.","uri":"09f4345b99b45e8082b8fe948c35d3de.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"How goes it ?","uri":"bd57e03d3f14ba258ec9e44d956a820f.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"I don't have an exact plan for you I'm afraid. You know the city better than any of us so are best placed to make a plan yourself. However as I said before, there have been sightings of mourners crossing the Arandar mountain pass. I'm sure you can take advantage of that.","uri":"7fb26afabbaf91aa56c4f8bb6062949d.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"I'd argue that understanding is essential to what comes next. But as you wish.","uri":"8ef547823ad7d1f5eb26a1e7ca18beb4.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"I'm afraid that a lot is still unknown to us as well. However, I will explain what I can. Be aware that this is only a brief overview. You'll find some books around the village that explain more if you wish though.","uri":"79870cb2f00056a8217df52f4b1cdf2f.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Indeed. After that, Baxtorian returned to the east but found that the rest of the kingdom had fallen while he was away. Not only that, but his wife, Glarial, had been taken.","uri":"2f50711f0501cdef63bd312b6adf14f8.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"It was built by Seren herself to guard a dark and ancient power. This is not good friend, I fear Lord Iorwerth intends to use that power to summon the Dark Lord!","uri":"8b5d1c430eb477d947c508d9a42ceb76.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Many years ago, all elves lived in harmony within the crystal city of Prifddinas alongside our goddess, Seren. When the God Wars ended, Seren was lost to us. For the first time, we were alone. To lead us through those difficult times, Baxtorian Cadarn was named the first king of the elves. Under Baxtorian, our kingdom expanded into the east. We prospered for a time, but little did we know that an enemy walked among us. During that time, Lord Iorwerth turned away from Seren and pledged himself to Zamorak, the Dark Lord. A larger kingdom meant our forces were further spread. Lord Iorwerth took advantage of that. He claimed Prifddinas as his own. Baxtorian tried to take it back from him, but Prifddinas was built to survive the God Wars. There was no way to retake it. In a last attempt to keep the city safe, Baxtorian and the clan elders sung the song of inversion which reverted the entire city into a crystal seed.","uri":"18d3c863df3245757fd84a7f9defd64d.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Temple? That must be the Temple of Light!","uri":"9547459a6836011c5ccf57a3580e3e5c.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"That is the bit we're not so sure on. We know little about the lands to the east. From what we can tell, it seems that Lord Iorwerth has promised to support King Lathas in reclaiming some land his family once owned.","uri":"005991190a3031c487fde3bf2f898307.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"That they are. We assume that the plague is a cover up for them to enter the city unchallenged. We don't know why though. That's why we need you.","uri":"2d9c7706ea364f0633d25fd3ddde81c8.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"That they are. We assume that the plague is a cover up for them to enter the city unchallenged. We don't know why though. That's why we need you. You know the city and can freely travel there. You are the perfect person for this task. We need you to go to West Ardougne, infiltrate the mourners and find out what they are doing in the city.","uri":"0aaaebf559bdd745cade3adeccc3b280.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"That's good to hear, I can see why you managed to earn Islwyn's trust. Anyway, with Baxtorian gone and Prifddinas lost, our land erupted into a Civil War. We've been fighting ever since.","uri":"f5594a95a9ac9bcb5cf548194f36d041.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"That's not surprising, he is not particularly fond of humans. But if you've earnt his trust, it proves to me that I was right to take a chance on you.","uri":"08606911dd87bc60a94d1025c444e797.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"That's what we want you to find out. According to our spies, Lord Iorwerth has used the alliance with King Lathas as an opportunity to infiltrate West Ardougne. The city must contain something he needs.","uri":"351df9c49912abfb3685d57363c86e78.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"The bit that is relevant to you is the recent alliance between King Lathas and Lord Iorwerth.","uri":"b4bbb0e6162ee9f8233ab81a191b2c04.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Those that you know as mourners are in fact elves in service to Lord Iorwerth. We regularly see them crossing the Arandar mountain pass and into the east.","uri":"216ecaf099fb37f4bef6d9bfdb6660d4.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Well don't take too long. Every second we waste is a big risk.","uri":"5bfcbc24563e9ce312e472c35a91a000.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Well then we still have time. Thank you for your help so far, we would never have discovered this without you. Now we must prepare for what comes next.","uri":"cbc9dde4b83dedb642d10eff7c8e3420.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"Well you're here now and you still have a chance to right your previous wrongs.","uri":"716b25c5969a816a82da7e70202b0ad9.mp3"}
+{"quest":"Mourning's End Part I","character":"Arianwyn","text":"You know the city and can freely travel there. You are the perfect person for this task. We need you to go to West Ardougne, infiltrate the mourners and find out what they are doing in the city.","uri":"687cdebd1835bf251493b25a0ebfedd9.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"! How's it going? Have you found out any more about the plague?","uri":"c803eb2f2c238e2c35105ff01094418c.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"? I didn't recognise you in all that Mourner gear!","uri":"9a473211377c4850cd0d5edc9f7bc698.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"? I didn't recogonise you in all that Mourner gear!","uri":"bd0d145a9532845e9943dc9ae1cc1aeb.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"And Lord Iorwerth?","uri":"0b59ea9dc51d674d5af17dd14d7bcaa4.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"But that was a lie?","uri":"ef0664d59bf5d9b00d62b5dd719888c8.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Did he say why?","uri":"19e8f527a9c8839856e6f2b65452c7bc.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Hello. Have you found out what those mourners are up to yet?","uri":"48a3302abbbe58d36df64e93fc93d6c4.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Hey, how are you?","uri":"a7d737a881ff7c071bc05a78ffda3b5c.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Hmm... That sounds like they were ill from some sort of toxin, I should think it was a mould of some sort that had the effect, not the rotten apple itself. What do you need it for?","uri":"ca71906734eb1eda4230d0d836da80cc.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"How dare you enter my house, Mourner! Get out!","uri":"f40190ea6e2f8da4942aae1afa1c9060.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Huh? Oh hello. I just can't get used to a friend being dressed as mourner.","uri":"5f2d0249761c875c6dce607e09f2aaf1.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"I doubt any poison based solely on apples, rotten or not, would be very effective.","uri":"fa70058f7bb9e454b809c5c5c44588b3.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"I see, that's quite the reveal. If you need anything from me just ask.","uri":"a35d88995938dc21faa014b336fffaec.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"I worry about what you've got yourself involved in. You be careful out there.","uri":"12fd492023e1b2f25fd3a7883fc5dc31.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"I would, but I don't have the right equipment here to do anything in bulk.","uri":"a657311f44478ba9ea66f8f4453f0cef.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Ick... Alright then let's get started.","uri":"83108cfca362a4f1248f32435b9339a4.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Is that you ?","uri":"033afd40f962d6343723ad306e3e639a.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Lying? About what?","uri":"1aafff84242e3120f2c2db2d7ffc1c58.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"No problem.","uri":"9d83ea8f204bf3636ebc5852d49a5bf8.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Not bad, did you speak to the king?","uri":"fa13fd9bc208e3c8673cae04b4de9a12.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Okay, I've managed to isolate a small sample of the toxin. It's a byproduct of the mould that grows on these apples, it's not fatal so a counteractant shouldn't be necessary. How big is the store that you're going to affect?","uri":"754daea3cde2af2eae6d10620fbe7e4f.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Perfect. Well get yourself some naphtha and some mashed rotten apples and mix them together. Once you've done that, strain out any solids. Finally, heat the mixture to evaporate off the solvent. Be careful of naked flames as the solvent will be highly flammable.","uri":"f0736c3a7e6d1907fe583fbe2fd36b1d.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Right then, the first thing to do is mash up a lot of rotten apples, then you will need to dissolve the toxin into a liquid that has a very low evaporation point, some form of solvent. I don't know as much about those kinds of chemicals but I believe naphtha will be perfect for this.","uri":"5656a9de6d8dda493a0ab3c153cdd3ca.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Right, the first thing to do is mash up a lot of rotten apples. You'll probably be able to do that at the orchard just north of the city. I hear no one has tended it since the blight infected the trees there. Next, you'll want to get yourself some naphtha and mix it with the rotten apples. You mentioned the chemist in Rimmingon helped you with naphtha before. You might want to speak to him again. Once that's done, use the sieve I gave you to strain out any solids. Finally, heat the mixture to evaporate off the solvent. Be careful of naked flames as the solvent will be highly flammable.","uri":"761f6a8df565c09ab240f12068ae5eb2.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Right.. lets see...","uri":"070cac239a0d2a91e48e71d00b97014d.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"So have you found out what those mourner are up to yet?","uri":"ed0fced737afbf3dde77a5e819a5b05c.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"So how's the poisoning going?","uri":"818d8ed83fbf578d1a1e4b2427e5705f.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Sorry, I never said it would be simple. Here, you'll need this to strain out the solids.","uri":"0888c4cca975a80171bb83e6369e67a1.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"That's awful, I can't help you with that.","uri":"cce8d4d1f9dbff2feb12edb1a9cd8c8a.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"That's over half of the food in the city! You're going to need a huge amount of the toxin to do that. You're also going to need to refine it too, or people will notice rotten apples in amongst the food.","uri":"25ae0cffed0848eb877966bd381608ee.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"This doesn't sound good at all. Should we tell someone?","uri":"37662c2be86d3d26f7489e14deee5f4b.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Well I'm not going anywhere. What's going on?","uri":"d74338af880a88aeb133a96514765d71.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Well if you bring me one we can get started on this toxin.","uri":"20cb318a2b0302e3e95e10103b032ef1.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Well let me know as soon as you have something. And look after yourself out there, I worry about what you've got yourself involved in.","uri":"e2b9ba0cda5bc2d23d446f81d7455504.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"Well let me know when you find out.","uri":"91dd4c337b2ed6483ba78c5f5cc5035f.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"What did it say?","uri":"3ae3ad398408840a0da488d152d9dc21.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"What's the problem?","uri":"59dc091b644594affd3c2889856657d8.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"You have a sample of rotten apple for me?","uri":"648f373e3a19006e18f62f6a1c1f517a.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"You may want to check out the orchard just north of the city. I hear no one has tended it since the blight infected the trees there. I imagine it will have plenty of rotten apples.","uri":"c9f056aa02898b28cf24a59b7de7c526.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"You'd better be right about this, and I'd better make sure you get this toxin right so no one dies! Bring me a sample of rotten apple to examine. I'll also see if I can make a counteractant for the toxin.","uri":"72f39b501323d3379bd58da9f963ecd0.mp3"}
+{"quest":"Mourning's End Part I","character":"Elena","text":"You'd better. Let me know as soon as you work out what's going on.","uri":"c692f1c2b90c648733f1a9fcb803f8b9.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"A long time ago, Seren herself ordered the construction of a great temple deep beneath the earth. This temple guards a great power, one that is key to our plans. We believe the temple lies beneath this city. That is why we are here. Unfortunately, progress has been slower than we'd have liked. The slaves accidently mined into some old caverns infested with beasts. They have caused us significant issues.","uri":"18b3665a417b39480754711d817d7ba7.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Ah... I take it you are one of the new recruits?","uri":"5f700ce5f52196902561bf8017a8143f.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Did they not tell you? Hmm... I'd better fill you in. Well as you undoubtedly know, we were sent here by Lord Iorwerth to secure the city. The reason for this is so that we can access the caves below...","uri":"5067352576e5d72681ad6b33d3543888.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Don't forget the part where you use the poison to contaminate the food supply. Two of the three supply points should be enough.","uri":"e555644ff29c3b0268df1d90217bfbe5.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Have you finished with those sheep yet?","uri":"579bc21c02b6101dedd0eb52285ae900.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Hmm, fair enough.","uri":"1ae5d6d0586a0fd8c64e2607c1dd640f.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"I also keep copies of the key on my desk so I can replace that too.","uri":"f075591cd0cf05994068de536dda83ea.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"I keep copies of the key on my desk so I can replace that.","uri":"ea704935e92aa37ce4f6dac3aca4d50b.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"I'm afraid that information is classified until you prove your commitment to the Death Guard.","uri":"03f69791842c38cf4b91481d662bb2cc.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"I'm Essyllt and I'm in charge here. Now come on, let us have a look at your paper work.","uri":"d34970e053b4e39816be7d0b5d5ee506.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"It is good to see your enthusiasm. I was going to get one of the others to do this job, but as you are here... It has been quite some time since anyone got ill form the plague, so I would like you to see to it that people do!","uri":"10bbc0540cc120072f64a8014b0af077.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"It shouldn't be long now. We have started to see signs that we are near. Anyway, now that you know about the temple, I have a new task for you to perform, deep within the mines. Alas, one of the guards has taken the key to the mines to be copied. Report in regularly and I will see that you get a copy as soon as he gets back.","uri":"fb9cf15bb502d51bbeb059d2871f24d1.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"No, the guard is being a bit slow, but we should have it soon.","uri":"45bb3a891b6e8d8a23769ba074ad1e8a.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Not quite, for starters the sheep need to be dyed red, yellow, green and blue. But most important is that you are not seen doing this by anyone. Also you will need to re-dye them the colours they already are or the farmer may notice the change.","uri":"6b899e2a31cbaafeca55796c807ef407.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Now be on your way, I have other things to attend to.","uri":"7fae2066734c342ab75b81e828b985da.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Now to keep our presence in the city secret, Lord Iorwerth arranged an alliance with King Lathas, the ruler in the east. Apparently the fool thinks we will help him dispose of the Knights of Camelot once our work here is done. I expect he'll be disappointed. Anyway, the plague serves two purposes. First, it allows us to move around the city in secret thanks to our mourner disguises. Second, it means we can abduct citizens to mine the caves below with ease. We just pretend they've fallen victim to the plague.","uri":"6af742997731ee3668d3b7ec45729a5b.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Someone trustworthy I hope?","uri":"9deb07aa001913467c2764d3ba54e8a7.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Subtle as a brick... Yes that, how is it going?","uri":"c0fa14c3d71af10e0045948d1a08b8f5.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Sure. We have a gnome inventor here too. Sadly, he is not being very helpful about fixing it, but you can talk to him if you like. Here is the key, he is in the next room. And here's the device as well.","uri":"5e51a463d27144def2f119990e8ba321.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"This is good news, give it a few days and the slave pens will be full again.","uri":"b4269cf2ed59d642c071aa86e537353a.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"This seems to be all in order. Welcome to the Death Guard. Now, for your first assignment... As you may know, part of what we do here is keep the people believing in the plague...","uri":"b69e9bbb3f7dd78863ec9526aa91770c.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Very well. Perform this task and then return to me.","uri":"dcc28db1b91c8e3f0d63499bdb956ca7.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"We have a gnomic device that fires fat dye parcels that rupture on impact. Unfortunately, we have run out of the parcels and the device is broken.","uri":"dc68b75fd570ccfb2537f9f0168c0367.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"We have never tried this before, but some joker put something in our food not too long ago that gave us all symptoms akin to those of the plague. If you can find out what it was that we were poisoned with, you could reproduce the effects. If done right the poison should not be fatal and could help restock our dwindling supply of cheap labour. We can have our men remove the 'infected' citizens and sent into the mines. Distribution should be easy enough. Because of the city walls no one can grow their own food. Instead, all the food here comes from one of three supply points.","uri":"0629abf2b8016dbb99f55be8b09054d7.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Well it is lucky we have a whole stack of broken devices, there must be some flaw in the design, they always break in the same way. If you ever need another there is a chest full of them over there.","uri":"5445f065723f4107164ca15850650d46.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Well it is lucky we have a whole stack of broken ones, there must be some flaw in the design, they always break in the same way. If you ever need another there is a chest full of them over there.","uri":"d36462a5d138852840f8439503f4142d.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Well we have had a few near misses. Recently we had some girl from East Ardougne poking around asking too many questions, so we locked her up while we decided what to do with her. Annoyingly, she managed to escape with the help of some adventurer. Lucky for us, they were so stupid that we managed to use the adventurer to deal with King Tyras. It all worked out quite well in the end. Things like that is why we must ensure the people keep believing in the plague though. One of the things we do to keep up the lie is to fool old Farmer Brumty into believing his sheep are infected. The old halfwit thinks just because his sheep are an abnormal colour, that they are all ill with plague. It's amazing what a bit of dye can do.","uri":"a6477547c7d48557d2063b8633ffbdb4.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Well you don't think they end up those ridiculous colours naturally do you? Anyway, shame of it is that we have yet to find a way to stop the dye from washing out. So we need someone, that someone being you, to go and re-dye them.","uri":"afdbc906598fca234f1ae09b5d848a17.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"What was that?","uri":"e7e8097b4fe505e92d3b32c9b563c671.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"Yes I think you have. I guess you want to know what we're doing in the mines?","uri":"8117e07b316abe798b2b5a8731272c29.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"You are back already? How is the epidemic going?","uri":"113f3337448a4cfdfd2366e754960e22.mp3"}
+{"quest":"Mourning's End Part I","character":"Essyllt","text":"You seem resourceful so I'm sure you will come up with something. I would help you but I am not a biologist.","uri":"e9c9fd1965a70a61b775fa5a4418dc3b.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Ahh they're fine, a bit of dye never hurt anything... It's the firing them out the device that kills them.","uri":"7f54e5a27c34ea74a2bcb6a5c4fa6123.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Catching chompy birds? You mourners are weird. Anyway, if you don't need anything else I'd like to be left in peace.","uri":"ed47ab32566c0b9f6491f3a9d59d0f35.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Does it?","uri":"cd213facd3e04eff95ea6d4c8688568d.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"How forgetful are you? Get some bellows and fill them with the dye you want. Then just head down to the Feldip Hills, find a toad and use the bellows to fill it up.","uri":"66e4abf0e0d7239257c5378999cf0ef1.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"I got no need for that, keep it.","uri":"dfc99eb9c1472c27336f0a3a15e57e47.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Maybe you should give me more toad crunchies. Ask any gnome, 'toad should be in everything' they'll tell you, mark my words.","uri":"7f70bb34f4a1757b8da7a29995ed728b.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Oh and torturing gnomes is perfectly fine? Hypocrite.","uri":"a62903075eecd79becda4f449dfbd765.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Right, here you go. Now leave me to eat my crunchies in peace.","uri":"75703c5d140a0e83e0591988b3bf2bd9.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Thanks... Toads always hit the spot!","uri":"75fb428cb01b8edcc764c0387d436867.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Well if you don't need anything else I'd like to be left in peace.","uri":"dc1ca38ad8cf90fabfd2e7d1c465dd30.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"What are you after now?","uri":"da92790bc952fe6a89761b79775e6382.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"Yes, toads. Get some bellows and fill them with the dye you want. Then just find a toad and use the bellows to fill it up.","uri":"72838246b15a739473147146d109f01a.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"You get loads of them down in the Feldip Hills, especially near the ponds.","uri":"feab5d3d11f506c4ed2fe44f2f2ee347.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome","text":"You mourners are really not very good at this are you? Fine, since you gave me some crunchies, the parcels are actually toads.","uri":"f3371dfeb2afceb32b420adf72ed40a0.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Alright... alright! I'm beaten! Bring me some soft leather and some magic logs and I'll see what I can do.","uri":"e792e6450ae7609b0578896d4c89f3f4.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Ha! You think I'm stupid enough to tell you that I've been craving toad crunchies or that I can't stand having my feet tickled!","uri":"58d546b423b9bf74eb4240a4005657df.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Ho ho ho... no more... Teehee... please stop... Hoohoo... he he he... I hate you!","uri":"20357ee33564babb2f7fa12889bccdd7.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"I did? What did I say?","uri":"beaf1bd39c30aef66eca59f02613de43.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"I told you, I'm not going to get anything out of helping you, am I? As I figure, that device is the only thing keeping me out of the slave pens, where I'd get fed worse than nail and prune stew!","uri":"fa2e5d3b6b27c24c7e2cd3f6da9a8a66.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"I used to play gnomeball yes.... what's that got to do with anything? Nothing that can convince me to help you that's for sure. Go away imbecile.","uri":"71d95d3ec82aede40c636c3b8988fcbc.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"I'm not helping you fix that, as if it hasn't caused enough trouble as it is. Your friends have already tried every torture in the book! I'm still not telling anyone squat.","uri":"84312c08167ad2969f4500dbdf445adc.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"If you think you can just buy my co-operation you're a bigger imbecile than I thought.","uri":"6f6a6788ba436362dc27b17b7fe36668.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"No... I said being here is a walk in the park. Where do they get you guys? You must all be Ogre rejects for being too thick. Leave me be idiot.","uri":"9ef495f5739326a50c3c30204696bb44.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Oi! There's no need for that, I already agreed to help.","uri":"f6a600b9d49dbce6379c1a668185893b.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Oooh... a big scary gnomeball. I mean, it might crush me and my entire family, because we're so small!! They have big teeth and everything don't they? Sheesh. You mourners will have to try better than that. Now go away. I need some sleep after all these *yawn* scary threats.","uri":"f87a1d10244d9d3524d98e348ed00dd6.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Oops... I mean erm... No that must have been some other err... gnome...","uri":"0d54e407bfe8dad8bfb04c1c6d829fcc.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"That's all I've been living on since I got here.","uri":"2962860eaf1ff1df4e5b9cc0752eb066.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Us gnomes aren't wise so we don't get them. Face it, you'll never put me in enough pain that I'll tell you what you wanna know. I used to play gnomeball as a kid. This is a walk in the park in comparison.","uri":"658c091feec01979e5724c8e0afb5be3.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Well let me up off of this rack and I'll get started, I can't do anything while I'm all tied up.","uri":"e38851e812d2a46fd0a4ec610981ee96.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Well when you have it all I'll fix that thing, but please don't tickle me any more.","uri":"a8fb77c5b1912ab24b8093b19f56a39f.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Yes yes!! That was it, I'd hate that. Please don't do that. By Guthix's beard you mourners are such idiots! Leave me be moron.","uri":"c5b7aa0dc00e474be035899ce296af07.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Yes, it didn't work.","uri":"62325186901575d3e9c47f1372aad63d.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"Yes, yes and yes. Tried them all, quite liked the toe nibbling.","uri":"d92385494d78e753238def1fdb730899.mp3"}
+{"quest":"Mourning's End Part I","character":"Gnome on a rack","text":"You got everything?","uri":"f883d94c14585e719f0c65ac7be7e1d7.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"Are the townspeople causing you trouble?","uri":"aff99409b585d64e1226a43efc2b5a4a.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"Do I look friendly to you? I really must work on my scowl more.","uri":"bffd115e5c13eac29cb3077998a2ecf0.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"Good day. Are you in need of assistance?","uri":"bfc5c50e1520dda06b3883fb56e9a5ca.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"Indeed it is. You should speak with Essyllt downstairs. He's in charge.","uri":"ac5037486d586798ab07e14411c95c35.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"It is good to see so many new recruits, soon no one will be able to stand against the power of the Death Guard.","uri":"15a0446b827b58270c21124429fe1898.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"Okay, but without the proper paperwork he stays in this room.","uri":"ab39ed232591a94bd03cbb7b30ffc9d7.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"What do you think you are doing? You are meant to be getting information out of him, not making friends!","uri":"e0811b0c1ac5ea649e47fcd4e1ee8dfe.mp3"}
+{"quest":"Mourning's End Part I","character":"Mourner","text":"You will be surprised at how much help the brute force of the Guard can be.","uri":"a7af63853a0bdf2c4100c4ae5b73434b.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"Any time.","uri":"dee221df3c5ebd2310cbf288e254f5c8.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"Hello, can I help?","uri":"1a5d36570bb93feaade3fd3e1bcde569.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"I do, but human clothes are too hard to mend. They do not have the finesse of elven garments.","uri":"ed9e1758241433a56d6cbd2f61225979.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"I need bear fur and one piece of silk.","uri":"ceaf0673bfe4ab79e44ca8d0b4534a66.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"I need bear fur and two pieces of silk.","uri":"be652dfd8106942e35b6cb5160fb3df5.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"I need two pieces of silk.","uri":"7d971ac66732f8f179ce1b0351be53bb.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"I only need bear fur now.","uri":"72b9902cfa17a4c1ef84e8082aa84e00.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"I only need one piece of silk.","uri":"d33ff5ace0e7e2952895047a7d031255.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"Let me take a look at it then.","uri":"45e419b05b607a463fa21818f1fb05ad.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"Of course I can, but I will need two pieces of silk and some bear fur.","uri":"aa92474067534b68ef59df11bfbe7873.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"Pass it all here then, and I will get started.","uri":"63c72c622f6dcc643e24913fac34b93b.mp3"}
+{"quest":"Mourning's End Part I","character":"Oronwen","text":"There's something disturbingly familiar about the design of these trousers, they are made for an elf.","uri":"8bfe7dbc96cdcbed5a482bfb85430d6f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"About his loyalty. It seems the plague is part of some evil plan of his. I still don't know what that is though.","uri":"58f35343f725bb8aa515d345be5e4fc9.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Ah yes, I've used them to catch chompy birds before. I have some bellows right here as well.","uri":"fd1fbfd8034e57c372d7d33d2c3163af.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Ah yes, I've worked with naphtha before. The chemist in Rimmington helped me make it from coal tar.","uri":"418edb520cdd71d97511d7cba0722e6e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Ah, so that explains why the city just looks like an empty field.","uri":"4f002f90e4c552343a9d1a8ea7dd4f6e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright can you tell me where I can buy some?","uri":"d99fd3d9359a241555bc31cda2e92c3f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright I get the picture. What will work then?","uri":"2ebe496426048cd8470feba6a8e77bce.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright I'll be back shortly with a rotten apple for you.","uri":"03cc30aaf14dc7ef83592b7fc834dc6b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright then, tell me the process and I'll get started.","uri":"71a3469e2e7da92cb62823f887876304.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright, I'll report in again later.","uri":"4ee08b919b7c8aac702188e08e563e2f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright, I'll see what I can do.","uri":"8db3337ba545f6942a3331348470b522.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright, I've managed to infiltrate the mourners. I just have to find out what they are up to now.","uri":"451beaff42db0478f08bdb4f57b16696.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Alright.","uri":"0f58c3cc3a6cf6e9f82030fc6c474486.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"And that's all is it? Why isn't anything ever easy?","uri":"663df7597ad605c114cbe51d69c2a20d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Apparently they are trying to find an old temple deep under the city. That's what their mining operation is for. The temple seems to be the key to their plans. It apparently holds a great power. I still have no idea what that is yet though.","uri":"d81381ad66fe1f5b893d5816ba4da923.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"As it goes, yes I have. It's a long story.","uri":"924089820fca08f819029742ea5440f2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"But can you fix them?","uri":"390c16481d6c7494ade9b1f41649e3ae.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"But why? What's in it for Lord Iorwerth.","uri":"cbed3396bf18a5a302fc757ff761b8b5.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Can I take a look at it?","uri":"64efcada526d469a45252ac1286123ac.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Could you be less helpful?","uri":"676cee2525174541978a750f8b003dce.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Could you remind me where I can get the dye parcels for this thing?","uri":"0ee5b0f5c3d2400ca57d5eb9afea5771.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Do you have the key to the mines yet?","uri":"636fbeea9b72352b8f34b423f488ff73.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Do you know any way to remove blood stains?","uri":"5fbcbfde5ed24d2c96e63025d2e86ebb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Do you know where I can get the dye parcels for his thing?","uri":"bc33eb02657880036a57e7fc65051f8f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Do you mend clothes?","uri":"7331cc372f5219ce4bf39f8dc3907d72.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Doesn't anyone suspect the truth?","uri":"87f8b6faa5f0ec9bac312554ff6aa3cb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Elena, it's me....","uri":"b2df5ccff9e5b1bf022086839033bd3c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Err... But the plague doesn't exist, how am I meant to do that?","uri":"e65303feaab4c05fc4235ecf678b039e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Err... But you just told me?!?","uri":"676f96b0e860f11813a9bc494b5a612f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Ewww... That's nasty.","uri":"4934fd47ad5870b998575288b0d972e0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Extracted your wisdom teeth?","uri":"af223d4afdeea186f9bca40015958bce.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Good day.","uri":"1c7a47ed6f856207d20dab51b68b0134.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Good thanks, yourself?","uri":"6d4257a6bae9f3564f5f607704c6a4cc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Have they tried... err... Stretching your eyelids yet?","uri":"285ec5d7cca6ce368f352f8c5b18133d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"He did. Turns out he was lying to me though.","uri":"6dfcf36ddda4531eb5195864c15668b5.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Hello again Elena.","uri":"ae919d04dfb07519687c9d9f15f2fc31.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Hello, I'm...","uri":"a5639913454f435bc98bc2db06d0ef09.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Hello, will you help me fix this... err... thing?","uri":"5262d921b08f1acad0f7ca38937b56c4.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Hello.","uri":"dc53029f6d2c3bb5144a3d14e4bf3650.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Hey Elena.","uri":"37c766379973dfdc9e9404ad31322e98.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"How about... feeding you nail and prune stew?","uri":"a53257e46c6e20dd346ed3e9e1a08494.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"How am I meant to do all of that?","uri":"d8ed060bce3437d8e76f3209af175134.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I did, he admitted the plague is a hoax.","uri":"1afdf3783e933cc867e257a2c086353b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I do have a bit of an issue though. The top has blood on it and the trousers are ripped.","uri":"51347cde09f1aa092648b16d82171bd7.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I don't think I am.","uri":"4fa58f66cbd07618a4c3e3f5776f7a82.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I don't think they've found this temple yet, but they know it's down there.","uri":"b041323ab9e8b10d8767d21ac41a6924.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I have all I need to mend my trousers.","uri":"b58bf991cb1da5373c3d05e575567c23.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I have all of that here.","uri":"0c0d86f98de6aca92047bc6df2118f7a.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I have it all here.","uri":"db00f2446927cc28734dca8a2375ac2e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I have one right here.","uri":"82b9ca8f235f2661bfcc884052a6270d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I hope so. There's a lot I still don't understand though. Why are King Lathas and Lord Iorwerth working together? Where does the plague fit in?","uri":"77da21f7137ffe27422d6c154f4087bc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I killed one of those mourners crossing the mountain pass and took their clothes.","uri":"e2019badd9d6221e48fdc76a4e4b2933.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I know this bit, Baxtorian retreated into his home beneath the waterfall and never came out. I moved Glarial's remains into the waterfall so they could be together.","uri":"31fd9723b8a737603e44321e493aaa9a.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I need to let him up if he's to fix this advice.","uri":"2fd48e9ca7b13319b3c39fda263a8895.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I need to poison a large food supply in order to get the Mourners' trust.","uri":"9474186557e01a94510eabc34963a202.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I need you to repair some elven clothing as it goes.","uri":"b52f82f7fe5bf7d14406201a6b20f17c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I see, it's good to have a bit more understanding. But where does King Lathas come into this?","uri":"7df9276a47d7fedc3e0290997985deb6.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I see. But how close are we to finding it ?","uri":"ba39b2e2778e1b85d38a2a46a8c55e12.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I still need some magic logs.","uri":"78a5c4dbc6e39af7b43edd6c5fdde398.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I still need some soft leather.","uri":"421b6c2ba193be7a97cbf023342e643e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I think I have the information you're after. It seems Iorwerth elves are searching for an ancient temple of some sort deep beneath West Ardougne.","uri":"19227e7330373f731d232eb2ab49e62f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I was just on my way back there.","uri":"3146fe0f9615d3e72649e666a9384fc9.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I will.","uri":"b380685cc82328b19c8a20f85d4c6fde.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'll be careful Elena. I promise.","uri":"206f4ebde4114bbccd7b0d8b2d116113.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'll look after myself Elena. I promise.","uri":"2e48f7c4236eea66e1e184682a77f5cf.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'm back.","uri":"21836d058901334bdaa9e3c135371b6c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'm glad you did. I hate the thought that I might still be blindly working for King Lathas and Lord Iorwerth right now.","uri":"b1464a192c67e4f476dbb593c1789990.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'm not exactly sure yet. West Ardougne seems to be key to his plans though. I met with Arianwyn who revealed to me that the mourners are actually elves in service to Lord Iorwerth. I've infiltrated the mourners and I'm trying to work out what they are doing. From what I've learnt so far, there's something important to them in the caves below West Ardougne. I'm currently working with them to earn their trust. Hopefully they'll reveal their plans to me soon.","uri":"db1b95dd6a679f282fed18f254bae73b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'm ready.","uri":"704be41b39e27496150a45834d2e7350.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I'm sorry but I lost the key.","uri":"4e00e2fa696449a554bc6374f4db9251.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"I've been asked to produce a poison based on rotten apples.","uri":"e8bee6eb8068cea66d41e3d409143bd9.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"If I don't gain the trust of the Mourners, then the people of West Ardougne will have a much worse time than the effects of that toxin. Elena trust me.","uri":"3fc84beaa3edac2284e93112e5c21cf9.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Indeed, but I didn't find out until much later. On the kings orders, I travelled through the Underground Pass and into the western lands of Tirannwn. Once there, I met up with Lord Iorwerth, the leader of some elves that had allied with the king. He helped me kill King Tyras. That was when I discovered the truth. While returning to King Lathas, I was confronted by another elf named Arianwyn, the leader of a group of rebel elves opposing Lord Iorwerth. At the time, I was carrying a letter from Lord Iorwerth to King Lathas. Arianwyn magically broke the seal on the letter so I could read it.","uri":"bc5992c87fb8974dbd73f1e2081ec77f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Infiltrate? How?","uri":"afe06b741a2552732a10815166df58c7.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"It revealed that it's actually King Lathas and Lord Iorwerth who serve the Dark Lord. According to the letter, King Lathas wants to reclaim Camelot from King Arthur and believes the Dark Lord can help him.","uri":"febf1b5f7cf1bb894699da695ebeeb7b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"It's a long story.","uri":"f95d399244fe003ee6877501aaf18291.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"It's all done.","uri":"8ac680b46a02276a9ff8508f75e5f892.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Let me get this clear, you want me to find out who poisoned you, find out what they poisoned you with, find out how to make the poison and produce enough poison to affect a lot of people?","uri":"b26287e83b721d803c95f2582b7f155b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Let's skip the backstory.","uri":"4f6aa967184de3fe267e427fe281b818.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Luckily for me I know a biologist nearby.","uri":"2262b8fa8199fb2bccabf61620dbf3a0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Mourners are elves?","uri":"8e830ccfe4b1736cd12308c8587ee35b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Nice day for it.","uri":"214cf74acbb625c0e2b6444adffa4791.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"No, I forgot to get one.","uri":"aa03092c4eb166effdc79fe210c4bb8e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"No, I just wanted to talk to a friendly face.","uri":"f9fbd19c17a47bf39daa563af83ac713.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"No, I'm sorry I lost the gnomic device and the key.","uri":"315a7f4714955c09e75c2615d64c5b1e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Not really, no.","uri":"76a3c4f85c6593fb7f9e48f9dcd93695.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Not too well, can you remind me how I should make it again?","uri":"9f4b3f04206b1d74ab056a3460d2dee8.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Not yet, I lost the gnomic device.","uri":"6e9ac418df6b54af5d856cf7ce1fd095.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Not yet. I still need to work out exactly what's going on. I have some new allies who might help me with that though.","uri":"b40c217a71f07f0d0e444e09135324bd.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Nothing I'm just talking to people randomly in case it helps.","uri":"4e0f2a24757228eb3b4a4713d619bb6e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Now will you help me or do I have to tickle your feet some more?","uri":"94a98d744741b033769398484cbbe297.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Now will you help me or would you prefer it if I tickle your feet?","uri":"280fcc03fd6c83452efa2e6d5364acdb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Oh nothing.","uri":"74efc0f3d66899a1b656843c03a1b859.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Oh yes, definitely.","uri":"ed89b15118813d5445864f0018e8cf96.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Oh, fair enough.","uri":"6cc3e34469943f9aac42d70c781e1282.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Okay, let's begin.","uri":"b772a2772a7ccbdaf592e49f0b37b8b5.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Okay, thanks Elena.","uri":"3d3234a51ba21b8e63c71c60481c74bb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Okay, thanks for the help.","uri":"04c9d25f26e1ab6d609f35ba0cba627f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Okay, will do.","uri":"68d9b52580d6b810f2edca04494b046c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Poor toads.","uri":"7751f05107f1b356ccee7010725317ee.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Really?!? That sounds like just the thing I need, can I use some?","uri":"c10e7be81a637f424b43056820663def.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Set fire to your nostril hair? Let rabid rabbits nibble your toes? Given you a twisted arm?","uri":"dede1ae799666df01ab627e25f0bb900.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Simple enough, you want me to give a blue rinse to a load of old sheep?","uri":"5c05b7ff87baaf41fc3c2c13a728a898.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"So have I proved my commitment now?","uri":"dc048615505c7a2e2e42f59255776701.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"So what are we going to do about the Temple of Light?","uri":"c7c0bb525526d9b933c585549a111f6b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"So you want me to infiltrate the mourners? How am I supposed to achieve that?","uri":"2999974e1b17cdcfb5f623d4512825be.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"So, you're doing laundry, eh?","uri":"64f2247a7fc4f81bd8f8bd34a09a1f29.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Sorry, didn't mean to scare you.","uri":"eae007e4d5a3ae39716cbad22cd67207.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Temple of Light? What's the Temple of Light?","uri":"b476f58b1c2b28a935999ca78ad23985.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Thank you. It wasn't particularly easy to get here, it took some work to convince Islwyn I could be trusted.","uri":"073629cf91dd67f038f453ed10212207.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Thanks a lot.","uri":"6ad9d335714b6ee2d4925f7258b3f6e2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Thanks for the reminder. I have some bellows right here that I can use.","uri":"353825fea21e08ddc7af61a62af712ef.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"That sounds a little more tricky. How did you do it before?","uri":"97c980935c5daa51a35c02be0050e27e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"That sounds... err great.","uri":"b1fb0f8cf19f6bfa3ae48b43164f9c74.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"That's all well and good but I'm enjoying doing it.","uri":"2b648c4cf6cc7ff7c987faba71a50131.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"The epidemic? Oh, you mean the poisoning?","uri":"239b031821e3a59e9e81c93c445db7b4.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"This is starting to sound a little tricky, can't you make it for me?","uri":"5432a65090f904ba2f7a3baeda3c6902.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Toads?","uri":"d7d4ae4508ffab8f25a78f62c43e0309.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Well I put a rotten apple in the Mourners' stew, I'm told that the effect was much like the symptoms of the plague.","uri":"534321127c522c7ab9779f5402891013.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Well I was instructed to contaminate two of the three supply points in West Ardougne.","uri":"fe0849f53c1bf283789aa714ddc3daf1.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Well I'll be sure to ask if I'm in need of some muscle.","uri":"1da908bff569f919d063c4561dbbfe20.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Well I'll start from when we found out that the plague was a hoax. When I confronted the king, he told me that he faked the plague to keep people safe from his brother, King Tyras. He said that Tyras was taken by the Dark Lord while exploring the lands to the west. He claimed that the Dark Lord corrupted him by forcing him to drink from the Chalice of Eternity.","uri":"fbecbfe8183d87b452053bf50ef9bd79.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Well, I was hoping you could help me with something.","uri":"a01f5e0ad06c34f81e9c5a12069deaaf.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Well, I'm...","uri":"a1a6671e63acaf1f58de0819cf4eff0f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"What do you need to mend my trousers?","uri":"279c74e91cdbf3a42ac0105770798987.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"What's important about the caves?","uri":"592536d33e6f844d0e2226bbdcbe3519.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Why?","uri":"eb69c5a1577f3f5210852d698584847a.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Will do.","uri":"dbae6100fb64af33d4293920915fa837.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Yes I have it right here.","uri":"4deb96f8a3d8d3510de78c44a6276f4d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Yes it's me.","uri":"6518ae6592ac32073db8cdb9ae8ea64b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Yes please.","uri":"3ab74c8ca337f0354810fa47da8d856d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Yes, but I don't think you can help","uri":"d7e611819bf2d3abf84ab0cf32cd4515.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"Yes, it is done. What next?","uri":"1f41322f6c5d9166c779d47f66d5f713.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You dyed them?","uri":"4adcd47cee749d636639a5953e81a27f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You make a fair point. Where do I find the toads?","uri":"dff81a14a5cc751ecc24e0a14fe59479.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You said about being tickled and a gnome ball.","uri":"d29d5e934f6dfd60d5695221c04dee75.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You said about being tickled and going to the park.","uri":"5dbbec784109dc6a246e02ca1a4ed111.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You said about going to the park and playing gnomeball.","uri":"deb6873b4a0cbd9e7882d7936738204e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You said about toad crunchies and a gnome ball.","uri":"dd8a0d92f0bfdd3e4761b6603f67483a.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You said about toad crunchies and being tickled.","uri":"afe6922be23117125b2740017ec1ab29.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You will tell me, sooner or later.","uri":"bc6ae2d4125fc212d2d9727ca66fdcc6.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Female","text":"You're not fooling me... So you'll help me in exchange for toad crunchies?","uri":"81b940cf174452eb28915dfa97458e3c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"About his loyalty. It seems the plague is part of some evil plan of his. I still don't know what that is though.","uri":"a688c928d3b32531122c6a581ecf8adc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Ah yes, I've used them to catch chompy birds before. I have some bellows right here as well.","uri":"fb1dd0eb47c9e87fb419444724548e17.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Ah yes, I've worked with naphtha before. The chemist in Rimmington helped me make it from coal tar.","uri":"0e3e64aa8439408b911da43e1fbee58b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Ah, so that explains why the city just looks like an empty field.","uri":"2d8c574f520f30222c853880d346b3bc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright can you tell me where I can buy some?","uri":"ca4edee02068e7c6c704e27a9e62919f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright I get the picture. What will work then?","uri":"71f89853a8c1028d1c933a81f48bb1d9.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright I'll be back shortly with a rotten apple for you.","uri":"7516b257cf5e9dc1ce1804c9554ca8e0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright then, tell me the process and I'll get started.","uri":"a66d96e34e929e7d278d5b1c7c6760c0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright, I'll report in again later.","uri":"03a656c74a7f795f9cbc1d9554df0661.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright, I'll see what I can do.","uri":"b287e9a2518d7ef41aa4c5be53a51eef.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright, I've managed to infiltrate the mourners. I just have to find out what they are up to now.","uri":"50c7e71b4c0a6a5eea421e40e1ddf5ed.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Alright.","uri":"0e87cf2413ba03b9678fa2d5123c1651.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"And that's all is it? Why isn't anything ever easy?","uri":"c31c182d644041f2710422e61fbe10ae.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Apparently they are trying to find an old temple deep under the city. That's what their mining operation is for. The temple seems to be the key to their plans. It apparently holds a great power. I still have no idea what that is yet though.","uri":"fa6aa8c91d325c887adbf599b5869198.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"As it goes, yes I have. It's a long story.","uri":"b3270a82c59ba477b0b8baf83c1edf56.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"But can you fix them?","uri":"73c1127a6832f90b7e68020f3de75bf6.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"But why? What's in it for Lord Iorwerth.","uri":"2099b0013e49011c2798ec356c312154.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Can I take a look at it?","uri":"2a47ed0016824da20927d6a081bb2f19.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Could you be less helpful?","uri":"0e47827d3629e8de0ff1015eb3cd0c6f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Could you remind me where I can get the dye parcels for this thing?","uri":"4e5fde654d706bd2abe32277a64cc1d7.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Do you have the key to the mines yet?","uri":"bdfc27e12cf0f0eb08b86e48deb8f54d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Do you know any way to remove blood stains?","uri":"325ad955253804fcce95fd30ecd04bda.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Do you know where I can get the dye parcels for his thing?","uri":"c5d7145f6d364f83aa463e5856cb702c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Do you mend clothes?","uri":"b58890cf2016df2875352528e0a1bc87.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Doesn't anyone suspect the truth?","uri":"b5da5f2c030715cadfb1c6de9d21edc1.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Elena, it's me....","uri":"f5e8e53188c06a88560e4b043bcd0a83.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Err... But the plague doesn't exist, how am I meant to do that?","uri":"89c116880e368899a92f782999ea3ed7.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Err... But you just told me?!?","uri":"ecb40af7b6b72692351af30e54efae1c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Ewww... That's nasty.","uri":"e593d150ba412a4bc10cee96620648e6.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Extracted your wisdom teeth?","uri":"9bd5acf10fac4f996b840e224056ffb0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Good day.","uri":"68981b4b89d6d11b48e0717aa3e508a7.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Good thanks, yourself?","uri":"89f438e5cabcdb46ce53c75dc38e4d2e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Have they tried... err... Stretching your eyelids yet?","uri":"42e45467b9564164aca6c91c2cd769e0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"He did. Turns out he was lying to me though.","uri":"c397be228cb2f5818a7f854931fc2303.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Hello again Elena.","uri":"8dcb5090c6e90d67627b157ab39ad0cb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Hello, I'm...","uri":"591ea94ad50f0f6c309319acbcc686d4.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Hello, will you help me fix this... err... thing?","uri":"36470eae02b004e8506f6ef744e4fefc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Hello.","uri":"ede3fbca98ea2533821b1cc25d109b50.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Hey Elena.","uri":"4b0ab815198c9f28cb12db28ef9bf578.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"How about... feeding you nail and prune stew?","uri":"7950c704832967f85b88a302dcb94698.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"How am I meant to do all of that?","uri":"7e2deac2b76d4b4aa1be046f794c33b3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I did, he admitted the plague is a hoax.","uri":"ef476025bfd143ef627669c463c9df8d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I do have a bit of an issue though. The top has blood on it and the trousers are ripped.","uri":"9b202f96afd15e4bc1ba441dd914d9ca.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I don't think I am.","uri":"30bf9f7f93c54f36b9ab52d3c3effb7f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I don't think they've found this temple yet, but they know it's down there.","uri":"8327e15f0854e45da2cc6a9e8db246cc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I have all I need to mend my trousers.","uri":"90ff2bc907cca6615cf55d5dc57d4e6b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I have all of that here.","uri":"8c27b1b666db3098f2e7ef6bf375232b.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I have it all here.","uri":"c729ddc33952b3a6214584499748aa88.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I have one right here.","uri":"022f2d618d68cd64c085482fe991ef83.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I hope so. There's a lot I still don't understand though. Why are King Lathas and Lord Iorwerth working together? Where does the plague fit in?","uri":"19f8e2b52135a0c3a15d088244c57d18.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I killed one of those mourners crossing the mountain pass and took their clothes.","uri":"91e6795c3b7fc3148a4a5341fae1c4fb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I know this bit, Baxtorian retreated into his home beneath the waterfall and never came out. I moved Glarial's remains into the waterfall so they could be together.","uri":"91c14123de555e3a89a3a1da1ce8831f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I need to let him up if he's to fix this advice.","uri":"06f759368dad00d748c11e2e9222ee28.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I need to poison a large food supply in order to get the Mourners' trust.","uri":"b601a9db44cac7f5a2a1a2616fe91570.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I need you to repair some elven clothing as it goes.","uri":"1ecce5b47c76ccb1cb5cfc14764dadd2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I see, it's good to have a bit more understanding. But where does King Lathas come into this?","uri":"3a46b2394c1754854555ef33bb6e20f9.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I see. But how close are we to finding it ?","uri":"3847e54fe02d17af940fdd8d3b556103.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I still need some magic logs.","uri":"0d1b7c2510d9b31ea4eebbd8b248fb93.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I still need some soft leather.","uri":"154e15816aeea9fb791ecb8df4bb6db2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I think I have the information you're after. It seems Iorwerth elves are searching for an ancient temple of some sort deep beneath West Ardougne.","uri":"865f9fda868b0f4d29cc602343ef6f17.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I was just on my way back there.","uri":"31f4c1f5a621c3de6558bde08e8bc3ce.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I will.","uri":"7f42b5fd7f16ce5f37f36a9f1d7672b3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'll be careful Elena. I promise.","uri":"be87d1e36c7da7f917b7eb28de054eb8.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'll look after myself Elena. I promise.","uri":"7c4201398468b00843519436bfff3253.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'm back.","uri":"538bb08a91d4249f6a6f5bafb19ea376.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'm glad you did. I hate the thought that I might still be blindly working for King Lathas and Lord Iorwerth right now.","uri":"5533c21b010dfa96a6ad9d6f6bcbadeb.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'm not exactly sure yet. West Ardougne seems to be key to his plans though. I met with Arianwyn who revealed to me that the mourners are actually elves in service to Lord Iorwerth. I've infiltrated the mourners and I'm trying to work out what they are doing. From what I've learnt so far, there's something important to them in the caves below West Ardougne. I'm currently working with them to earn their trust. Hopefully they'll reveal their plans to me soon.","uri":"8615b60921d288186c1e6109fde1b294.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'm ready.","uri":"6b31a91f8de1d336f1541d28be710df0.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I'm sorry but I lost the key.","uri":"2d491565744ce2e4ebb2863b05f49edc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"I've been asked to produce a poison based on rotten apples.","uri":"ae602669af79b7e12e4d420694e14291.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"If I don't gain the trust of the Mourners, then the people of West Ardougne will have a much worse time than the effects of that toxin. Elena trust me.","uri":"167859f24815a121f094b964a9e1d713.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Indeed, but I didn't find out until much later. On the kings orders, I travelled through the Underground Pass and into the western lands of Tirannwn. Once there, I met up with Lord Iorwerth, the leader of some elves that had allied with the king. He helped me kill King Tyras. That was when I discovered the truth. While returning to King Lathas, I was confronted by another elf named Arianwyn, the leader of a group of rebel elves opposing Lord Iorwerth. At the time, I was carrying a letter from Lord Iorwerth to King Lathas. Arianwyn magically broke the seal on the letter so I could read it.","uri":"5112f2e6cfc187b4a1c6d721558668ea.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Infiltrate? How?","uri":"a0ef53ada94cecb9024b6180fde9661d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"It revealed that it's actually King Lathas and Lord Iorwerth who serve the Dark Lord. According to the letter, King Lathas wants to reclaim Camelot from King Arthur and believes the Dark Lord can help him.","uri":"9126210e0e7b6f98910ce3b151ca9988.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"It's a long story.","uri":"05f4e321a44dc04e7dcd3a0824b0fa15.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"It's all done.","uri":"cf2b83b02655d7819993ae21b4de040d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Let me get this clear, you want me to find out who poisoned you, find out what they poisoned you with, find out how to make the poison and produce enough poison to affect a lot of people?","uri":"faa3dd62ed879342399a6b2534ac47b3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Let's skip the backstory.","uri":"058e561373ff1fb1a4bfba4ad60f74db.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Luckily for me I know a biologist nearby.","uri":"4aa91e2ff46a964e9218a4e4b75a8490.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Mourners are elves?","uri":"fd18bff6663cdbfa6f06fb2cc173b2ba.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Nice day for it.","uri":"b1195dd6863ae6195e5d06177e9693e2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"No, I forgot to get one.","uri":"ec7c0f6ecac87fff9aa0be54b282a695.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"No, I just wanted to talk to a friendly face.","uri":"9d8e8dfeb1499e5c566d4b9654328a4f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"No, I'm sorry I lost the gnomic device and the key.","uri":"8694276e803e4bc72e5bd8acfc841ac2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Not really, no.","uri":"aaee066e1c5b433e9c6f1ff8de19782c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Not too well, can you remind me how I should make it again?","uri":"d102fd2fa13260baee78740086ea1cad.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Not yet, I lost the gnomic device.","uri":"bfb4d326f752a4e3ad8f60579c1bfd4a.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Not yet. I still need to work out exactly what's going on. I have some new allies who might help me with that though.","uri":"7e43e024bb2cab55444d65ffd7f8cad1.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Nothing I'm just talking to people randomly in case it helps.","uri":"af48a2c052aaafa5510e2ca1cbf5641d.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Now will you help me or do I have to tickle your feet some more?","uri":"d21ba8de24fb1311743cda886b8f0e10.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Now will you help me or would you prefer it if I tickle your feet?","uri":"6503bfce3e0ad20e7229adac6b3db891.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Oh nothing.","uri":"fe3fe207350a4add309e7314a44d1acd.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Oh yes, definitely.","uri":"512fa82995c33d9b2cf26dc24e6c8938.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Oh, fair enough.","uri":"6e7a739120774701e5289ffbda5d72c5.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Okay, let's begin.","uri":"f74521a08e15c582b2b884370e1ffbb4.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Okay, thanks Elena.","uri":"b8accc45eda34ff5604f0ac9653b1a75.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Okay, thanks for the help.","uri":"5e0341a611c03d73462d23b3dc6308f4.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Okay, will do.","uri":"723639de44e440749cb927a4e109a41e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Poor toads.","uri":"8b73ea8d01d04ff73db897c02b1cb4e2.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Really?!? That sounds like just the thing I need, can I use some?","uri":"4f7372f56159cfa6025a705d44e6f782.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Set fire to your nostril hair? Let rabid rabbits nibble your toes? Given you a twisted arm?","uri":"2607b4d44c7c2e862a1c9195fc955f86.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Simple enough, you want me to give a blue rinse to a load of old sheep?","uri":"a12ab2d0c3b2a411e7fcb775bffe0321.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"So have I proved my commitment now?","uri":"af776f1d995aa33035ffea0ac208ff29.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"So what are we going to do about the Temple of Light?","uri":"67bdb365d1e216c8c88591b254bdb762.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"So you want me to infiltrate the mourners? How am I supposed to achieve that?","uri":"2c5de45be0126d69b1e4bc077e50d03e.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"So, you're doing laundry, eh?","uri":"02c601edabcf0d7a7be058e9fff191a1.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Sorry, didn't mean to scare you.","uri":"69ef13b98019731db148e5f300b33ead.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Temple of Light? What's the Temple of Light?","uri":"9f6796ca9730f2974fc3e1b114745cc8.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Thank you. It wasn't particularly easy to get here, it took some work to convince Islwyn I could be trusted.","uri":"0af9faed0fa88a162b7299e71228b1e1.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Thanks a lot.","uri":"21dcbe0448e7487682b0056cadcb05e3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Thanks for the reminder. I have some bellows right here that I can use.","uri":"ce6d461611766e6416dee58ed15137c8.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"That sounds a little more tricky. How did you do it before?","uri":"1c62b5fa0727fbb6031650d03e2972a7.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"That sounds... err great.","uri":"2a2ddc3bb5a8bf75573a6f0746485a8c.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"That's all well and good but I'm enjoying doing it.","uri":"898d455e5ab65e447c7e8a363b02d211.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"The epidemic? Oh, you mean the poisoning?","uri":"17e58389bd60b108cf90b21748ec79b4.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"This is starting to sound a little tricky, can't you make it for me?","uri":"aee124c42abeced352fd721a5535b475.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Toads?","uri":"5423cd29a27fbcee6683eb016fb028a3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Well I put a rotten apple in the Mourners' stew, I'm told that the effect was much like the symptoms of the plague.","uri":"506c3efcd1f4a4b5374f6d8baa90e09f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Well I was instructed to contaminate two of the three supply points in West Ardougne.","uri":"d139125b4135386beb27ee1de0a3695f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Well I'll be sure to ask if I'm in need of some muscle.","uri":"7d9fb7b1b45c6149e8124a2fc3131905.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Well I'll start from when we found out that the plague was a hoax. When I confronted the king, he told me that he faked the plague to keep people safe from his brother, King Tyras. He said that Tyras was taken by the Dark Lord while exploring the lands to the west. He claimed that the Dark Lord corrupted him by forcing him to drink from the Chalice of Eternity.","uri":"4b3ca680ef86fdeb3d216efe9704c6c5.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Well, I was hoping you could help me with something.","uri":"37c1d8b8781c1b5bfa2ef9af555a0114.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Well, I'm...","uri":"94ba52697eaa0511578a141e394bbcd3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"What do you need to mend my trousers?","uri":"728c43ede3ed3c31dd1651195f06f4b3.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"What's important about the caves?","uri":"ba0c9e89e50a7acc895ced86ba7d01cf.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Why?","uri":"629e796f7962ba2318bcc42da7195a23.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Will do.","uri":"dab658d11ffe5114da802ccff6963789.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Yes I have it right here.","uri":"805ab3adee28598ed7a835f7d41f2962.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Yes it's me.","uri":"64ffa9fd4e4621d1cd7d014dd3fb3664.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Yes please.","uri":"45bab0a52a497514f46ac628867256df.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Yes, but I don't think you can help","uri":"600e440d88e654c2fd34cc8c9951e166.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"Yes, it is done. What next?","uri":"a3ed5683ce5eec328ef1e9cf5ee5503f.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You dyed them?","uri":"1da3f6475fad53ac1055f41083bdc0dc.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You make a fair point. Where do I find the toads?","uri":"f03a4b881b69ab34402ed542c7601470.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You said about being tickled and a gnome ball.","uri":"e87639d136c26b3ec4eb14aec3ba1796.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You said about being tickled and going to the park.","uri":"3937bc320b3f04f9fc4176bc55e43248.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You said about going to the park and playing gnomeball.","uri":"2a8a280a08678af5bafbfd9bfd3332ad.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You said about toad crunchies and a gnome ball.","uri":"98c211c8122985c76f7dee4222ab9ec5.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You said about toad crunchies and being tickled.","uri":"14e6c58a0d00e5bd7dfa9052e8784679.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You will tell me, sooner or later.","uri":"07730c08ebcb5209319dc5db3132b5a6.mp3"}
+{"quest":"Mourning's End Part I","character":"Player Male","text":"You're not fooling me... So you'll help me in exchange for toad crunchies?","uri":"8691dd958f25d2905755a0a75c5151b1.mp3"}
+{"quest":"Mourning's End Part I","character":"Tegid","text":"Blood stains is it... Well, the soap I use can clean almost any stain.","uri":"cea1d3221f2e43b263dacb92f21047af.mp3"}
+{"quest":"Mourning's End Part I","character":"Tegid","text":"I suppose it is.","uri":"d10450fb59b45dda669bc1a02e1692d1.mp3"}
+{"quest":"Mourning's End Part I","character":"Tegid","text":"Like you were, taking those robes from my washing line?? So yes, if you know a way I can be less helpful just tell me. I'll try it.","uri":"d99f79d4462974dd14b1a986335e7aa9.mp3"}
+{"quest":"Mourning's End Part I","character":"Tegid","text":"No, I don't have very much soap left and I still have lots to get clean.","uri":"24cfce6356fbb8cef25021fb75754bc0.mp3"}
+{"quest":"Mourning's End Part I","character":"Tegid","text":"Yes. What is it to you?","uri":"36e8c8dffdf1577e3da4c490506fbca2.mp3"}
+{"quest":"Mourning's End Part I","character":"Tegid","text":"You can't... I make it to my own secret recipe.","uri":"3477b96c3cd8b9c0efc0316d2716e1e5.mp3"}


### PR DESCRIPTION
Dialog row shard for **Mourning's End Part I**. The database branch's workflow rebuilds quest_voiceover_v2.db from all shards on merge.